### PR TITLE
feat(react): usePreservedState 추가

### DIFF
--- a/.changeset/good-seals-remain.md
+++ b/.changeset/good-seals-remain.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat: usePreservedState 추가

--- a/docs/docs/react/hooks/usePreservedState.mdx
+++ b/docs/docs/react/hooks/usePreservedState.mdx
@@ -1,0 +1,32 @@
+# usePreservedCallback
+
+`comparator`로 비교했을 때 값이 변경되었을 때에만 상태를 변경하는 커스텀 훅입니다.
+
+comparator를 넘기지 않는다면 `@modern-kit/utils`의 `deepEqual` 함수가 활용됩니다.
+  - [deepEqual](https://modern-agile-team.github.io/modern-kit/docs/utils/common/deepEqual)
+
+만약, 변경되는 값이 같다면 상태를 변경하지 않습니다. 또한 참조가 유지됩니다.
+
+<br />
+
+## Interface
+```tsx
+const usePreservedState: <T>(
+  value: T,
+  comparator?: ((source: T, target: T) => boolean) | undefined
+) => T;
+```
+
+## Usage
+```tsx
+import React, { useEffect, useState } from "react";
+import { usePreservedState } from "@modern-kit/react";
+
+const Example = () => {
+  const preservedState = usePreservedState(exampleState);
+
+  return (
+    <>{/* ... */}</>
+  );
+}
+```

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './useIsomorphicLayoutEffect';
 export * from './useMediaQuery';
 export * from './useMergeRefs';
 export * from './useOnClickOutside';
+export * from './usePreservedState';
 export * from './usePreservedCallback';
 export * from './usePrevious';
 export * from './useResizeObserver';

--- a/packages/react/src/hooks/useAsyncPreservedCallback/index.ts
+++ b/packages/react/src/hooks/useAsyncPreservedCallback/index.ts
@@ -13,5 +13,5 @@ export const useAsyncPreservedCallback = <
 
   return useCallback(async (...args: any[]) => {
     return await callbackRef.current(...args);
-  }, []);
+  }, []) as T;
 };

--- a/packages/react/src/hooks/usePreservedCallback/index.ts
+++ b/packages/react/src/hooks/usePreservedCallback/index.ts
@@ -11,5 +11,5 @@ export const usePreservedCallback = <T extends (...args: any[]) => any>(
 
   return useCallback((...args: any[]) => {
     return callbackRef.current(...args);
-  }, []);
+  }, []) as T;
 };

--- a/packages/react/src/hooks/usePreservedState/index.ts
+++ b/packages/react/src/hooks/usePreservedState/index.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { usePreservedCallback } from '../usePreservedCallback';
+import { deepEqual } from '@modern-kit/utils';
+
+export const usePreservedState = <T>(
+  value: T,
+  comparator?: (source: T, target: T) => boolean
+) => {
+  const [preservedState, setPreservedState] = useState(value);
+  const callbackComparator = usePreservedCallback(comparator ?? deepEqual);
+
+  useEffect(() => {
+    if (!callbackComparator(preservedState, value)) {
+      setPreservedState(value);
+    }
+  }, [callbackComparator, preservedState, value]);
+
+  return preservedState;
+};

--- a/packages/react/src/hooks/usePreservedState/usePreservedState.spec.ts
+++ b/packages/react/src/hooks/usePreservedState/usePreservedState.spec.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { usePreservedState } from '.';
+
+describe('usePreservedState', () => {
+  describe('Default Comparator Callback 사용', () => {
+    it('값이 같다면 상태의 변경되서는 안됩니다. 이때 참조도 유지되어야 합니다.', () => {
+      const originObj = { group: 'modern-agile' };
+      const targetObj = { group: 'modern-agile' };
+
+      const { result, rerender } = renderHook(
+        ({ value }) => usePreservedState(value),
+        {
+          initialProps: { value: originObj },
+        }
+      );
+
+      rerender({ value: targetObj });
+
+      expect(result.current).toBe(originObj);
+      expect(result.current).toEqual(originObj);
+    });
+
+    it('값이 변경되면 상태가 변경되야 합니다.', () => {
+      const originObj = { group: 'modern-agile' };
+      const targetObj = { group: 'frontend' };
+
+      const { result, rerender } = renderHook(
+        ({ value }) => usePreservedState(value),
+        {
+          initialProps: { value: originObj },
+        }
+      );
+
+      rerender({ value: targetObj });
+
+      expect(result.current).toBe(targetObj);
+      expect(result.current).toEqual(targetObj);
+    });
+  });
+
+  describe('Custom Comparator Callback 사용', () => {
+    it('comparator가 true를 반환하면 상태가 변경되서는 안됩니다. 이때 참조도 유지되어야 합니다.', () => {
+      const comparator = (a: any, b: any) => a.group === b.group;
+
+      const originObj = { group: 'modern-agile', title: 'origin' };
+      const changedObj = { group: 'modern-agile', title: 'change' };
+
+      const { result, rerender } = renderHook(
+        ({ value }) => usePreservedState(value, comparator),
+        {
+          initialProps: { value: originObj },
+        }
+      );
+
+      rerender({ value: changedObj });
+
+      expect(result.current).toBe(originObj);
+      expect(result.current).toEqual(originObj);
+    });
+
+    it('comparator가 false를 반환하면 상태가 변경되야 합니다.', () => {
+      const comparator = (a: any, b: any) => a.group === b.group;
+
+      const originObj = { group: 'modern-agile', title: 'origin' };
+      const changedObj = { group: 'frontend', title: 'change' };
+
+      const { result, rerender } = renderHook(
+        ({ value }) => usePreservedState(value, comparator),
+        {
+          initialProps: { value: originObj },
+        }
+      );
+
+      rerender({ value: changedObj });
+
+      expect(result.current).toBe(changedObj);
+      expect(result.current).toEqual(changedObj);
+    });
+  });
+});


### PR DESCRIPTION
## Overview

비교 함수(comparator)를 통해 true를 반환하면 상태를 유지하고, false를 반환하면 상태를 변경하는 커스텀 훅인 usePreservedState를 추가합니다.

만약 상태가 유지된다면 참조까지 유지됩니다.

comparator는 인자로 넣지 않는다면 기본적으로 `@modern-kit/utils`의 [deepEqual](https://modern-agile-team.github.io/modern-kit/docs/utils/common/deepEqual)이 활용됩니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)