### PR TITLE
chore: git workflow document build  조건식 제거

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,4 +28,3 @@ jobs:
         run: yarn test
       - name: document build 🔨
         run: yarn build:docs
-        if: github.event.pull_request.user.login == 'dependabot[bot]'


### PR DESCRIPTION
## Overview

git workflow document build  조건식 제거

초기 의도에는 추가 문서 작업을 고려하지 않고 `dependabot`을 통해 의존성 변경 시에만 일반 build(test, typecheck포함) + build:docs를 함께 진행했는데, 일반적인 작업 시에도 추가/수정 문서 작업이 포함될 수 있기 때문에 build:docs가 정상 동작하는지 확인 할 수 있어야 합니다.
따라서, pull request  workflow에서 해당 조건식을 제거합니다.

해당 작업에 영감을 주셔서 감사합니다! @Sangminnn 

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)