### PR TITLE
refactor(react): Add fallback default function parammeter and change Condition's type

### DIFF
--- a/packages/react/src/components/When/index.tsx
+++ b/packages/react/src/components/When/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { PropsWithChildren } from 'react';
 
-type Condition = boolean | ((...args: any[]) => boolean);
+type Condition = boolean | (() => boolean);
 
 interface WhenProps {
   condition: Condition;
@@ -15,7 +15,7 @@ const getConditionResult = (condition: Condition) => {
 export const When = ({
   children,
   condition,
-  fallback,
+  fallback = null,
 }: PropsWithChildren<WhenProps>) => {
   const conditionResult = getConditionResult(condition);
 


### PR DESCRIPTION
## What I did

1. The `fallback` parameter is optional, so we provided the default value.
2. The `condition` function does not use parameters in the test code and business logic code, so I deleted the parameters.

## Overview

### Before

```jsx
type Condition = boolean | ((...args: any[]) => boolean);

// ...

export const When = ({
  // ...
  fallback,
}: PropsWithChildren<WhenProps>) => {
 // ...
};
```

### After

```jsx
type Condition = boolean | (() => boolean);

// ...

export const When = ({
  // ...
  fallback = null,
}: PropsWithChildren<WhenProps>) => {
  // ...
};

```




<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)