### PR TITLE
feat(utils): converImageToBase64 함수 추가

### DIFF
--- a/.changeset/swift-papayas-march.md
+++ b/.changeset/swift-papayas-march.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): converImageToBase64 함수 추가 - @ssi02014

--- a/docs/docs/utils/clipboard/clipboardImageCopy.md
+++ b/docs/docs/utils/clipboard/clipboardImageCopy.md
@@ -5,10 +5,11 @@
 `navigator.clipboard.write`는 일부 브라우저에서 지원하지 않습니다. `write`가 지원하지 않을 경우 [clipboardTextCopy](https://modern-agile-team.github.io/modern-kit/docs/utils/clipboard/clipboardTextCopy)가 호출 됩니다.
 
 Chrome 환경에서 Clipboard API의 `write()`는 `text/plain`, `text/html`, `image/png` 포맷만을 지원합니다. 따라서, `jp(e)g`, `webp`와 같은 이미지 포맷은 클립보드에 복사할 수 없습니다. 원활한 클립보드 복사를 위해서는 `png` 포맷의 이미지 사용을 권장합니다.
-- [Chromium - ClipboardWriter::IsValidType](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/clipboard/clipboard_writer.cc;l=304;drc=e882b8e4a8272f65cb14c608d3d2bc4f0512aa20)
-- 💡 **타 이미지 포맷을 png 포맷으로 변환하는 옵션을 추가 할 예정입니다.**
+- **[Chromium - ClipboardWriter::IsValidType](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/clipboard/clipboard_writer.cc;l=304;drc=e882b8e4a8272f65cb14c608d3d2bc4f0512aa20)**
 
-이미지 타입이 `image/svg+xml`의 경우에는 `소스 코드`를 복사해서 활용 할 수 있게 [clipboardTextCopy](https://modern-agile-team.github.io/modern-kit/docs/utils/clipboard/clipboardTextCopy)가 호출됩니다. 
+💡 만약, `jp(e)g`와 `webp`를 클립보드에 저장을 원한다면 `png`로 변환해서 저장해야 됩니다. 이를 위해 `toPng` 옵션을 `true`로 설정해주시길 바랍니다.
+
+💡 이미지 타입이 `image/svg+xml`의 경우에는 `소스 코드`를 복사해서 활용 할 수 있게 **[clipboardTextCopy](https://modern-agile-team.github.io/modern-kit/docs/utils/clipboard/clipboardTextCopy)**가 호출됩니다. 
 
 <br />
 
@@ -17,7 +18,15 @@ Chrome 환경에서 Clipboard API의 `write()`는 `text/plain`, `text/html`, `im
 
 ## Interface
 ```ts title="typescript"
-const clipboardImageCopy: (imgSrc: string) => Promise<void>
+interface ClipboardImageCopyProps {
+  src: string;
+  toPng?: boolean;
+}
+
+const clipboardImageCopy: ({
+  src,
+  toPng,
+}: ClipboardImageCopyProps) => Promise<void>;
 ```
 
 ## Usage
@@ -25,7 +34,12 @@ const clipboardImageCopy: (imgSrc: string) => Promise<void>
 ```ts title="typescript"
 import { clipboardImageCopy } from '@modern-kit/utils';
 
-clipboardImageCopy("복사 할 이미지 src");
+clipboardImageCopy({ src: "복사 할 이미지 src(png)" });
+
+clipboardImageCopy({ 
+  src: "복사 할 이미지 src(jp(e) or Webp)", 
+  toPng: true 
+});
 ```
 
 <br />
@@ -34,9 +48,9 @@ clipboardImageCopy("복사 할 이미지 src");
 ```ts title="typescript"
 import { clipboardImageCopy } from '@modern-kit/utils';
 
-clipboardImageCopy(
-  'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMS41IC0xMC4yMzE3NCAyMyAyMC40NjM0OCI+CiAgPHRpdGxlPlJlYWN0IExvZ288L3RpdGxlPgogIDxjaXJjbGUgY3g9IjAiIGN5PSIwIiByPSIyLjA1IiBmaWxsPSIjNjFkYWZiIi8+CiAgPGcgc3Ryb2tlPSIjNjFkYWZiIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIi8+CiAgICA8ZWxsaXBzZSByeD0iMTEiIHJ5PSI0LjIiIHRyYW5zZm9ybT0icm90YXRlKDYwKSIvPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIiB0cmFuc2Zvcm09InJvdGF0ZSgxMjApIi8+CiAgPC9nPgo8L3N2Zz4K'
-);
+clipboardImageCopy({
+  src: 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9Ii0xMS41IC0xMC4yMzE3NCAyMyAyMC40NjM0OCI+CiAgPHRpdGxlPlJlYWN0IExvZ288L3RpdGxlPgogIDxjaXJjbGUgY3g9IjAiIGN5PSIwIiByPSIyLjA1IiBmaWxsPSIjNjFkYWZiIi8+CiAgPGcgc3Ryb2tlPSIjNjFkYWZiIiBzdHJva2Utd2lkdGg9IjEiIGZpbGw9Im5vbmUiPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIi8+CiAgICA8ZWxsaXBzZSByeD0iMTEiIHJ5PSI0LjIiIHRyYW5zZm9ybT0icm90YXRlKDYwKSIvPgogICAgPGVsbGlwc2Ugcng9IjExIiByeT0iNC4yIiB0cmFuc2Zvcm09InJvdGF0ZSgxMjApIi8+CiAgPC9nPgo8L3N2Zz4K'
+});
 
 /* Clipboard 복사 결과: text()
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="-11.5 -10.23174 23 20.46348">
@@ -58,7 +72,9 @@ clipboardImageCopy(
 import { clipboardImageCopy } from '@modern-kit/utils';
 import svg from "./assets/react.svg";
 
-clipboardImageCopy(svg);
+clipboardImageCopy({
+  src: svg,
+});
 
 /* Clipboard 복사 결과: text()
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="-11.5 -10.23174 23 20.46348">

--- a/docs/docs/utils/clipboard/clipboardImageCopy.md
+++ b/docs/docs/utils/clipboard/clipboardImageCopy.md
@@ -20,7 +20,7 @@ Chrome 환경에서 Clipboard API의 `write()`는 `text/plain`, `text/html`, `im
 ```ts title="typescript"
 interface ClipboardImageCopyProps {
   src: string;
-  toPng?: boolean;
+  toPng?: boolean; // default: false
 }
 
 const clipboardImageCopy: ({

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -15,7 +15,7 @@ type ImageType = 'png' | 'jpeg' | 'jpg' | 'webp';
 
 const convertImageToBase64: (
   url: string,
-  imageType?: ImageType // default: png
+  imageType?: ImageType // default: 'png'
 ) => Promise<string>;
 ```
 

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -1,0 +1,27 @@
+# convertImageToBase64
+
+이미지를 `Base64` 형태로 변환해주는 함수입니다.
+
+💡 canvas.toDataURL()함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/file/convertImageToBase64/index.ts)
+
+## Interface
+```ts title="typescript"
+type ImageType = 'png' | 'jpeg' | 'jpg' | 'webp';
+
+const convertImageToBase64: (
+  url: string,
+  imageType?: ImageType // default: png
+) => Promise<string>;
+```
+
+## Usage
+```ts title="typescript"
+import { convertImageToBase64 } from '@modern-kit/utils';
+
+const imageBase64 = await convertImageToBase64("이미지 src", 'png');
+```

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -2,7 +2,7 @@
 
 이미지를 `canvas`를 활용해 원하는 이미지 포맷(`png`, `jpeg`, `webp`)의 `Base64` 형태로 변환해주는 함수입니다.
 
-💡 `canvas.toDataURL()`함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
+💡 `canvas.toDataURL()`함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/webp` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
 
 - **[HTMLCanvasElement: toDataURL() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)**
 
@@ -15,15 +15,15 @@
 
 ## Interface
 ```ts title="typescript"
-type ImageType = 'png' | 'jpeg' | 'jpg' | 'webp';
+type ImageType = 'image/png' | 'image/jpeg' | 'image/jpg' | 'image/webp';
 
 const convertImageToBase64: (
   url: string,
-  imageType?: ImageType // default: 'png'
+  imageType?: ImageType // default: 'image/png'
 ) => Promise<string>;
 ```
 
-## Usage
+## Usages
 ```ts title="typescript"
 import { convertImageToBase64 } from '@modern-kit/utils';
 

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -4,6 +4,10 @@
 
 💡 canvas.toDataURL()함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
 
+- [HTMLCanvasElement: toDataURL() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)
+
+> Browsers are required to support `image/png`; many will support additional formats including `image/jpeg` and `image/webp`.
+
 <br />
 
 ## Code
@@ -25,3 +29,6 @@ import { convertImageToBase64 } from '@modern-kit/utils';
 
 const imageBase64 = await convertImageToBase64("이미지 src", 'png');
 ```
+
+## Note
+- [HTMLCanvasElement: toDataURL() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -1,6 +1,6 @@
 # convertImageToBase64
 
-이미지를 `canvas`를 활용해 `Base64` 형태로 변환해주는 함수입니다.
+이미지를 `canvas`를 활용해 원하는 이미지 포맷(`png`, `jpeg`, `webp`)의 `Base64` 형태로 변환해주는 함수입니다.
 
 💡 `canvas.toDataURL()`함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
 

--- a/docs/docs/utils/file/convertImageToBase64.md
+++ b/docs/docs/utils/file/convertImageToBase64.md
@@ -1,10 +1,10 @@
 # convertImageToBase64
 
-이미지를 `Base64` 형태로 변환해주는 함수입니다.
+이미지를 `canvas`를 활용해 `Base64` 형태로 변환해주는 함수입니다.
 
-💡 canvas.toDataURL()함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
+💡 `canvas.toDataURL()`함수가 허용하는 이미지 타입은 `image/png`, `image/jpeg`, `image/png` 입니다. `jpg`의 경우 내부적으로 `jpeg`로 변경합니다.
 
-- [HTMLCanvasElement: toDataURL() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)
+- **[HTMLCanvasElement: toDataURL() - MDN](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toDataURL)**
 
 > Browsers are required to support `image/png`; many will support additional formats including `image/jpeg` and `image/webp`.
 

--- a/docs/docs/utils/file/getMIMETypeFromResponse.md
+++ b/docs/docs/utils/file/getMIMETypeFromResponse.md
@@ -13,7 +13,7 @@
 
 ## Interface
 ```ts title="typescript"
-const getMIMETypeFromResponse: (response: Response) => Promise<string>
+const getMIMETypeFromResponse: (response: Response) => string
 ```
 
 ## Usage

--- a/packages/utils/src/clipboard/clipboardImageCopy/index.ts
+++ b/packages/utils/src/clipboard/clipboardImageCopy/index.ts
@@ -1,12 +1,21 @@
+import { convertImageToBase64 } from '../../file';
 import { isClient } from '../../device';
 import { clipboardTextCopy } from '../clipboardTextCopy';
+
+interface ClipboardImageCopyProps {
+  src: string;
+  toPng?: boolean;
+}
 
 const fallbackImageCopy = async (res: Response) => {
   const textData = await res.text();
   await clipboardTextCopy(textData);
 };
 
-export const clipboardImageCopy = async (imgSrc: string) => {
+export const clipboardImageCopy = async ({
+  src,
+  toPng = false,
+}: ClipboardImageCopyProps) => {
   if (!isClient()) {
     console.error('Cannot be executed unless it is a browser environment.');
     return;
@@ -14,7 +23,10 @@ export const clipboardImageCopy = async (imgSrc: string) => {
 
   try {
     const hasNavigatorClipboard = 'clipboard' in window.navigator;
-    const response = await fetch(imgSrc);
+    const convertedImgSrc = toPng
+      ? await convertImageToBase64(src, 'png')
+      : src;
+    const response = await fetch(convertedImgSrc);
 
     if (!hasNavigatorClipboard) {
       await fallbackImageCopy(response);

--- a/packages/utils/src/file/convertImageToBase64/index.ts
+++ b/packages/utils/src/file/convertImageToBase64/index.ts
@@ -1,13 +1,13 @@
-type ImageType = 'png' | 'jpeg' | 'jpg' | 'webp';
+type ImageType = 'image/png' | 'image/jpeg' | 'image/jpg' | 'image/webp';
 
-const getAvailableToDataUrlImageType = (imageType: string) => {
-  if (imageType === 'jpg') return 'jpeg';
+const getAvailableToDataUrlImageType = (imageType: ImageType) => {
+  if (imageType === 'image/jpg') return 'image/jpeg';
   return imageType;
 };
 
 export const convertImageToBase64 = async (
   url: string,
-  imageType: ImageType = 'png'
+  imageType: ImageType = 'image/png'
 ) => {
   const img = new Image();
   img.src = url;
@@ -18,15 +18,24 @@ export const convertImageToBase64 = async (
       canvas.width = img.width;
       canvas.height = img.height;
 
-      const ctx = canvas.getContext('2d');
+      try {
+        const ctx = canvas.getContext('2d');
 
-      ctx?.drawImage(img, 0, 0);
+        if (!ctx) {
+          throw new Error('Failed to get 2d context');
+        }
 
-      const dataUrl = canvas.toDataURL(
-        `image/${getAvailableToDataUrlImageType(imageType)}`
-      );
+        ctx?.drawImage(img, 0, 0);
 
-      resolve(dataUrl);
+        const dataUrl = canvas.toDataURL(
+          getAvailableToDataUrlImageType(imageType)
+        );
+        resolve(dataUrl);
+      } catch (error: any) {
+        reject(
+          `Failed to convert the image to base64. message: ${error.message}`
+        );
+      }
     };
     img.onerror = () => reject('Failed to convert the image to base64.');
   });

--- a/packages/utils/src/file/convertImageToBase64/index.ts
+++ b/packages/utils/src/file/convertImageToBase64/index.ts
@@ -1,0 +1,33 @@
+type ImageType = 'png' | 'jpeg' | 'jpg' | 'webp';
+
+const getAvailableToDataUrlImageType = (imageType: string) => {
+  if (imageType === 'jpg') return 'jpeg';
+  return imageType;
+};
+
+export const convertImageToBase64 = async (
+  url: string,
+  imageType: ImageType = 'png'
+) => {
+  const img = new Image();
+  img.src = url;
+
+  return new Promise<string>((resolve, reject) => {
+    img.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = img.width;
+      canvas.height = img.height;
+
+      const ctx = canvas.getContext('2d');
+
+      ctx?.drawImage(img, 0, 0);
+
+      const dataUrl = canvas.toDataURL(
+        `image/${getAvailableToDataUrlImageType(imageType)}`
+      );
+
+      resolve(dataUrl);
+    };
+    img.onerror = () => reject('Failed to convert the image to base64.');
+  });
+};

--- a/packages/utils/src/file/getMIMEType/index.ts
+++ b/packages/utils/src/file/getMIMEType/index.ts
@@ -9,7 +9,7 @@ export const getMIMEType = async (data: string | File | Response) => {
     }
 
     if (data instanceof Response) {
-      return await getMIMETypeFromResponse(data);
+      return getMIMETypeFromResponse(data);
     }
 
     return await getMIMETypeFromUrl(data);

--- a/packages/utils/src/file/getMIMETypeFromResponse/index.ts
+++ b/packages/utils/src/file/getMIMETypeFromResponse/index.ts
@@ -1,7 +1,6 @@
-export const getMIMETypeFromResponse = async (response: Response) => {
+export const getMIMETypeFromResponse = (response: Response) => {
   try {
-    const blob = await response.blob();
-    return blob.type;
+    return response.headers.get('Content-Type') ?? '';
   } catch (err: any) {
     console.error(
       `Failed to get the MIME type from Response. message: ${err.message}`

--- a/packages/utils/src/file/index.ts
+++ b/packages/utils/src/file/index.ts
@@ -1,5 +1,6 @@
 // ignore test
 
+export * from './convertImageToBase64';
 export * from './getBlobFromUrl';
 export * from './getMIMEType';
 export * from './getMIMETypeFromFile';


### PR DESCRIPTION
## Overview

이미지를 Base64 형태로 변경해주는 `converImageToBase64` 함수를 추가했습니다.

`clipboardImageCopy` 함수에서 `webp`, `jp(e)g`의 경우 Clipboard 저장이 제한적입니다. 

이를 저장하려면 `png` 형태로 변경해서 저장을 해야됩니다. 이를 위해 `toPng` 옵션을 추가하고, toPng가 `true`일 경우 `converImageToBase64`를 활용해 base64의 png 포맷으로 변경 후에 클립보드에 저장합니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)