### PR TITLE
feat(react): useClientEffect 훅 추가

### DIFF
--- a/docs/docs/react/hooks/useClientEffect.mdx
+++ b/docs/docs/react/hooks/useClientEffect.mdx
@@ -1,0 +1,31 @@
+# useClientEffect
+
+클라이언트 환경에서만 실행되는 useEffect 훅
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useClientEffect/index.ts)
+
+## Interface
+```ts title="typescript"
+const useClientEffect: (callback: React.EffectCallback, deps?: React.DependencyList) => void;
+```
+
+## Usage
+```tsx title="typescript"
+import { useClientEffect } from '@modern-kit/react';
+
+const Example = () => {
+  useClientEffect(() => {
+    console.log("클라이언트 환경")
+  }, []);
+
+  return (
+    <div>
+      {bool && <p>render</p>}
+      <button onClick={toggle}>Toggle Button</button>
+    </div>
+  );
+}
+```

--- a/docs/docs/react/hooks/useClientEffect.mdx
+++ b/docs/docs/react/hooks/useClientEffect.mdx
@@ -23,8 +23,7 @@ const Example = () => {
 
   return (
     <div>
-      {bool && <p>render</p>}
-      <button onClick={toggle}>Toggle Button</button>
+        useClientEffect
     </div>
   );
 }

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -23,3 +23,4 @@ export * from './useUnMount';
 export * from './useVisibilityChange';
 export * from './useWindowScrollTo';
 export * from './useWindowSize';
+export * from './useClientEffect';

--- a/packages/react/src/hooks/useClientEffect/index.ts
+++ b/packages/react/src/hooks/useClientEffect/index.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+import { isServer } from '@modern-kit/utils';
+
+export const useClientEffect = (
+  callback: React.EffectCallback,
+  deps: React.DependencyList = []
+) => {
+  useEffect(() => {
+    if (isServer()) return;
+    callback();
+  }, deps);
+};

--- a/packages/react/src/hooks/useClientEffect/useClientEffect.spec.tsx
+++ b/packages/react/src/hooks/useClientEffect/useClientEffect.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, vi, expect, Mock } from 'vitest';
+
+import * as ModernUtilKit from '@modern-kit/utils';
+
+import { useClientEffect } from '.';
+
+// isServer 함수를 모킹하여 반환 값을 설정합니다.
+vi.mock('@modern-kit/utils', () => ({
+  isServer: vi.fn(),
+}));
+
+interface TestComponentProps {
+  callback: React.EffectCallback;
+  depsTest?: string;
+}
+
+const WithDependency = ({ callback, depsTest }: TestComponentProps) => {
+  useClientEffect(callback, [depsTest]);
+  return <div>Test Component</div>;
+};
+
+const WithoutDependency = ({ callback }: TestComponentProps) => {
+  useClientEffect(callback);
+  return <div>Test Component</div>;
+};
+
+describe('useClientEffect', () => {
+  const isServer = ModernUtilKit.isServer as Mock;
+
+  it('should not call the callback on the server', () => {
+    isServer.mockReturnValue(true); // 서버 환경을 시뮬레이트합니다.
+    const callback = vi.fn();
+
+    render(<WithDependency callback={callback} />);
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should call the callback on the client', () => {
+    isServer.mockReturnValue(false); // 클라이언트 환경을 시뮬레이트합니다.
+    const callback = vi.fn();
+
+    render(<WithDependency callback={callback} />);
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('should call the callback with dependencies', () => {
+    isServer.mockReturnValue(false); // 클라이언트 환경을 시뮬레이트합니다.
+    const callback = vi.fn();
+
+    const { rerender } = render(<WithDependency callback={callback} />);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender(<WithDependency callback={callback} />);
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    rerender(<WithDependency callback={callback} depsTest="newValue" />);
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('should use an empty dependency array when none is provided', () => {
+    isServer.mockReturnValue(false); // 클라이언트 환경을 시뮬레이트합니다.
+    const callback = vi.fn();
+
+    render(<WithoutDependency callback={callback} />);
+
+    expect(callback).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Overview

- 클라이언트 환경에서만 실행되는 `useClientEffect` 훅 추가
- 테스트 작성
  1. 서버 환경에서는 콜백이 실행되지 않아야 한다.
  2. 클라이언트 환경에서는 콜백이 실행되어야 한다.
  3. 클라이언트 환경에서는 의존성 배열에 따라 콜백이 실행되어야 한다.
  4. 의존성 배열이 비어있으면 빈 배열을 사용해야 한다.
 - mdx 문서 작성

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)