### PR TITLE
feat(react): useKeyDown 커스텀 훅 추가

### DIFF
--- a/.changeset/rich-hairs-push.md
+++ b/.changeset/rich-hairs-push.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useKeyDown 커스텀 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useKeyDown.mdx
+++ b/docs/docs/react/hooks/useKeyDown.mdx
@@ -1,12 +1,14 @@
-import { useKeyDown } from '@modern-kit/react';
-
 # useKeyDown
 
-ref를 전달한 요소가 포커싱된 상태에서 `keydown` 이벤트 발생 시 `keyDownCallbackMap`로 지정한 이벤트를 발생시킵니다.
+`ref`를 전달한 요소가 포커싱된 상태에서 `keydown` 이벤트 발생 시 `keyDownCallbackMap`로 지정한 `key`에 트리거되어 콜백 함수를 호출합니다.
 
 `keyDownCallbackMap`의 key는 `KeyboardEvent.key`가 반환하는 값이 들어가야 합니다.
 
-`autoFocus` 옵션을 `true`로 제공한다면 마운트 시 `focus()` 함수가 호출되서 자동 포커싱 됩니다.
+만약 `모든 KeyboardEvent.key`에 대해 콜백 함수를 호출하고 싶다면 `allKeyDownCallback` props를 이용 할 수 있습니다.
+  - 💡 **allKeyDownCallback이 존재 할 경우 keyDownCallbackMap으로 지정한 콜백 함수는 무시합니다.**
+
+`autoFocus` 옵션을 `true`로 제공한다면 마운트 시 ref를 제공한 요소의 `focus()` 함수가 호출되서 자동 포커싱 됩니다.
+
 
 <br />
 
@@ -17,18 +19,35 @@ ref를 전달한 요소가 포커싱된 상태에서 `keydown` 이벤트 발생 
 ```ts title="typescript"
 interface UseKeyDownProps {
   autoFocus?: boolean;
-  keyDownCallbackMap: Record<string, (event: KeyboardEvent) => void>;
+  keyDownCallbackMap?: Record<string, (event: KeyboardEvent) => void>;
+  allKeyDownCallback?: (event: KeyboardEvent) => void;
 }
 
 const useKeyDown: <T extends HTMLElement>({
-  autoFocus, // default: false,
+  autoFocus,
   keyDownCallbackMap,
+  allKeyDownCallback,
 }: UseKeyDownProps) => {
   ref: React.RefObject<T>;
 };
 ```
 
 ## Usage
+### AllKeyDownCallback
+```tsx title="typescript"
+import { useKeyDown } from '@modern-kit/react';
+
+const Example = () => {
+  const { ref } = useKeyDown<HTMLButtonElement>({
+    autoFocus: false,
+    allKeyDownCallback: (event) => console.log('All Key', event.key)
+  });
+
+  return <button ref={ref}>버튼</button>;
+};
+```
+
+### KeyDownCallbackMap
 ```tsx title="typescript"
 import { useKeyDown } from '@modern-kit/react';
 
@@ -36,8 +55,8 @@ const Example = () => {
   const { ref } = useKeyDown<HTMLButtonElement>({
     autoFocus: false,
     keyDownCallbackMap: {
-      Enter: (event) => console.log('Enter Click', event.key), 
-      Shift: (event) => console.log('Shift Click', event.key) 
+      Enter: (event) => console.log('Enter', event.key), 
+      Shift: (event) => console.log('Shift', event.key) 
     }
   });
 

--- a/docs/docs/react/hooks/useKeyDown.mdx
+++ b/docs/docs/react/hooks/useKeyDown.mdx
@@ -1,0 +1,50 @@
+import { useKeyDown } from '@modern-kit/react';
+
+# useKeyDown
+
+ref를 전달한 요소가 포커싱된 상태에서 `keydown` 이벤트 발생 시 `keyDownCallbackMap`로 지정한 이벤트를 발생시킵니다.
+
+`keyDownCallbackMap`의 key는 `KeyboardEvent.key`가 반환하는 값이 들어가야 합니다.
+
+`autoFocus` 옵션을 `true`로 제공한다면 마운트 시 `focus()` 함수가 호출되서 자동 포커싱 됩니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useKeyDown/index.ts)
+
+## Interface
+```ts title="typescript"
+interface UseKeyDownProps {
+  autoFocus?: boolean;
+  keyDownCallbackMap: Record<string, (event: KeyboardEvent) => void>;
+}
+
+const useKeyDown: <T extends HTMLElement>({
+  autoFocus, // default: false,
+  keyDownCallbackMap,
+}: UseKeyDownProps) => {
+  ref: React.RefObject<T>;
+};
+```
+
+## Usage
+```tsx title="typescript"
+import { useKeyDown } from '@modern-kit/react';
+
+const Example = () => {
+  const { ref } = useKeyDown<HTMLButtonElement>({
+    autoFocus: false,
+    keyDownCallbackMap: {
+      Enter: (event) => console.log('Enter Click', event.key), 
+      Shift: (event) => console.log('Shift Click', event.key) 
+    }
+  });
+
+  return <button ref={ref}>버튼</button>;
+};
+```
+
+## Note
+[KeyboardEvent.key(en) - MDN](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key)
+[KeyboardEvent.key(ko) - MDN](https://developer.mozilla.org/ko/docs/Web/API/KeyboardEvent/key)

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './useIntersectionObserver';
 export * from './useInterval';
 export * from './useIsMounted';
 export * from './useIsomorphicLayoutEffect';
+export * from './useKeydown';
 export * from './useMediaQuery';
 export * from './useMergeRefs';
 export * from './useOnClickOutside';

--- a/packages/react/src/hooks/useKeydown/index.ts
+++ b/packages/react/src/hooks/useKeydown/index.ts
@@ -1,0 +1,38 @@
+import { usePreservedCallback } from '../usePreservedCallback';
+import { useEffect, useRef } from 'react';
+
+interface UseKeyDownProps {
+  autoFocus?: boolean;
+  keyDownCallbackMap: Record<string, (event: KeyboardEvent) => void>;
+}
+
+export const useKeyDown = <T extends HTMLElement>({
+  autoFocus = false,
+  keyDownCallbackMap,
+}: UseKeyDownProps) => {
+  const ref = useRef<T>(null);
+
+  const onKeyDown = usePreservedCallback((event: KeyboardEvent) => {
+    try {
+      const callback = keyDownCallbackMap[event.key];
+      callback(event);
+      event.stopPropagation();
+    } catch (err: any) {
+      console.error(
+        `Failed to call the onKeyDown function. message: ${err.message}`
+      );
+    }
+  });
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    if (autoFocus) {
+      ref.current.focus();
+    }
+
+    ref.current.addEventListener('keydown', onKeyDown);
+  }, [autoFocus, onKeyDown]);
+
+  return { ref };
+};

--- a/packages/react/src/hooks/useKeydown/index.ts
+++ b/packages/react/src/hooks/useKeydown/index.ts
@@ -3,17 +3,24 @@ import { useEffect, useRef } from 'react';
 
 interface UseKeyDownProps {
   autoFocus?: boolean;
-  keyDownCallbackMap: Record<string, (event: KeyboardEvent) => void>;
+  keyDownCallbackMap?: Record<string, (event: KeyboardEvent) => void>;
+  allKeyDownCallback?: (event: KeyboardEvent) => void;
 }
 
 export const useKeyDown = <T extends HTMLElement>({
   autoFocus = false,
-  keyDownCallbackMap,
+  keyDownCallbackMap = {},
+  allKeyDownCallback,
 }: UseKeyDownProps) => {
   const ref = useRef<T>(null);
 
   const onKeyDown = usePreservedCallback((event: KeyboardEvent) => {
     try {
+      if (allKeyDownCallback) {
+        allKeyDownCallback(event);
+        return;
+      }
+
       const callback = keyDownCallbackMap[event.key];
       callback(event);
       event.stopPropagation();
@@ -27,11 +34,15 @@ export const useKeyDown = <T extends HTMLElement>({
   useEffect(() => {
     if (!ref.current) return;
 
+    const element = ref.current;
+
     if (autoFocus) {
-      ref.current.focus();
+      element.focus();
     }
 
-    ref.current.addEventListener('keydown', onKeyDown);
+    element.addEventListener('keydown', onKeyDown);
+
+    return () => element.addEventListener('keydown', onKeyDown);
   }, [autoFocus, onKeyDown]);
 
   return { ref };

--- a/packages/react/src/hooks/useKeydown/index.ts
+++ b/packages/react/src/hooks/useKeydown/index.ts
@@ -1,5 +1,6 @@
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 import { usePreservedCallback } from '../usePreservedCallback';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 
 interface UseKeyDownProps {
   autoFocus?: boolean;
@@ -31,7 +32,7 @@ export const useKeyDown = <T extends HTMLElement>({
     }
   });
 
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (!ref.current) return;
 
     const element = ref.current;

--- a/packages/react/src/hooks/useKeydown/useKeydown.spec.tsx
+++ b/packages/react/src/hooks/useKeydown/useKeydown.spec.tsx
@@ -9,10 +9,11 @@ const TestComponent = (props: Parameters<typeof useKeyDown>[0]) => {
 };
 
 describe('useKeyDown', () => {
-  it('should trigger the event provided to keyDownCallbackMap when a keyboard event occurs', async () => {
-    const enterMockFn = vi.fn();
-    const shiftMockFn = vi.fn();
+  const allKeyMockFn = vi.fn();
+  const enterMockFn = vi.fn();
+  const shiftMockFn = vi.fn();
 
+  it('should trigger the event provided to keyDownCallbackMap when a keyboard event occurs', async () => {
     const { user } = renderSetup(
       <TestComponent
         keyDownCallbackMap={{ Enter: enterMockFn, Shift: shiftMockFn }}
@@ -39,28 +40,38 @@ describe('useKeyDown', () => {
     expect(shiftMockFn).toBeCalledTimes(2);
   });
 
-  it('should automatically focus when autoFocus is true', async () => {
-    const enterMockFn = vi.fn();
-    const shiftMockFn = vi.fn();
-
+  it('should execute the callback function for all key', async () => {
     const { user } = renderSetup(
-      <TestComponent
-        autoFocus
-        keyDownCallbackMap={{ Enter: enterMockFn, Shift: shiftMockFn }}
-      />
+      <TestComponent allKeyDownCallback={allKeyMockFn} />
     );
 
-    await user.keyboard('{Enter}');
+    const button = screen.getByRole('button');
 
-    expect(enterMockFn).toBeCalledTimes(1);
-
-    await user.keyboard('{Shift}');
-
-    expect(shiftMockFn).toBeCalledTimes(1);
+    button.focus();
 
     await user.keyboard('{Enter}{Shift}');
 
-    expect(enterMockFn).toBeCalledTimes(2);
-    expect(shiftMockFn).toBeCalledTimes(2);
+    expect(allKeyMockFn).toBeCalledTimes(2);
+  });
+
+  it('should automatically focus when autoFocus is true', async () => {
+    renderSetup(<TestComponent autoFocus />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveFocus();
+  });
+
+  it('should call a console error if there is no function for the specified key', async () => {
+    const consoleErrorMock = vi.spyOn(console, 'error');
+
+    const { user } = renderSetup(<TestComponent autoFocus />);
+
+    const button = screen.getByRole('button');
+
+    button.focus();
+
+    await user.keyboard('{Enter}');
+
+    expect(consoleErrorMock).toBeCalled();
   });
 });

--- a/packages/react/src/hooks/useKeydown/useKeydown.spec.tsx
+++ b/packages/react/src/hooks/useKeydown/useKeydown.spec.tsx
@@ -1,0 +1,66 @@
+import { renderSetup } from '../../utils/test/renderSetup';
+import { useKeyDown } from '.';
+import { screen } from '@testing-library/react';
+
+const TestComponent = (props: Parameters<typeof useKeyDown>[0]) => {
+  const { ref } = useKeyDown<HTMLButtonElement>(props);
+
+  return <button ref={ref}>버튼</button>;
+};
+
+describe('useKeyDown', () => {
+  it('should trigger the event provided to keyDownCallbackMap when a keyboard event occurs', async () => {
+    const enterMockFn = vi.fn();
+    const shiftMockFn = vi.fn();
+
+    const { user } = renderSetup(
+      <TestComponent
+        keyDownCallbackMap={{ Enter: enterMockFn, Shift: shiftMockFn }}
+      />
+    );
+
+    const button = screen.getByRole('button');
+
+    expect(enterMockFn).not.toBeCalled();
+
+    button.focus();
+
+    await user.keyboard('{Enter}');
+
+    expect(enterMockFn).toBeCalledTimes(1);
+
+    await user.keyboard('{Shift}');
+
+    expect(shiftMockFn).toBeCalledTimes(1);
+
+    await user.keyboard('{Enter}{Shift}');
+
+    expect(enterMockFn).toBeCalledTimes(2);
+    expect(shiftMockFn).toBeCalledTimes(2);
+  });
+
+  it('should automatically focus when autoFocus is true', async () => {
+    const enterMockFn = vi.fn();
+    const shiftMockFn = vi.fn();
+
+    const { user } = renderSetup(
+      <TestComponent
+        autoFocus
+        keyDownCallbackMap={{ Enter: enterMockFn, Shift: shiftMockFn }}
+      />
+    );
+
+    await user.keyboard('{Enter}');
+
+    expect(enterMockFn).toBeCalledTimes(1);
+
+    await user.keyboard('{Shift}');
+
+    expect(shiftMockFn).toBeCalledTimes(1);
+
+    await user.keyboard('{Enter}{Shift}');
+
+    expect(enterMockFn).toBeCalledTimes(2);
+    expect(shiftMockFn).toBeCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Overview

#141 
원하는 요소에 `ref`를 넘겨주고, ref를 받은 요소가 포커싱 된 상태에서 `keydown` 이벤트 발생시 keyDownCallbackMap props로 지정한 특정 `KeyboardEvent.key`에 대한 콜백 함수가 호출되는 커스텀 훅입니다. `allKeydownCallback`를 통해 모든 KeyboardEvent.key에대한 함수 호출도 가능합니다.

autoFocus를 통해 자동 포커싱도 가능합니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)