### PR TITLE
fix(utils): deepCopy 순환참조 대응 및 Date, Regex 테스트 코드 추가

### DIFF
--- a/.changeset/happy-days-rescue.md
+++ b/.changeset/happy-days-rescue.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': patch
+---
+
+fix(utils): deepCopy 순환참조 이슈 수정 및 Date, Regex 테스트 코드 추가 - @hoonloper

--- a/docs/docs/utils/common/deepCopy.md
+++ b/docs/docs/utils/common/deepCopy.md
@@ -9,7 +9,7 @@
 
 ## Interface
 ```ts title="typescript"
-const deepCopy: <T>(source: T) => T
+const deepCopy: <T>(value: T) => T
 ```
 
 ## Usage

--- a/packages/utils/src/common/deepCopy/deepCopy.spec.ts
+++ b/packages/utils/src/common/deepCopy/deepCopy.spec.ts
@@ -3,33 +3,25 @@ import { deepCopy } from '.';
 describe('deepCopy', () => {
   it('should deeply copy a primitive value', () => {
     const originNum = 42;
-    const copyNum = deepCopy(originNum);
+    const copiedNum = deepCopy(originNum);
 
-    expect(copyNum).toBe(originNum);
-  });
-
-  it('should deeply copy an array', () => {
-    const originArray = [1, 2, [3, 4]];
-    const copyArray = deepCopy(originArray);
-
-    expect(copyArray).toEqual(originArray);
-    expect(copyArray).not.toBe(originArray);
+    expect(copiedNum).toBe(originNum);
   });
 
   it('should deeply copy an object', () => {
     const originObj = { a: 1, b: { c: 2 } };
-    const copyObj = deepCopy(originObj);
+    const copiedObj = deepCopy(originObj);
 
-    expect(copyObj).toEqual(originObj);
-    expect(copyObj).not.toBe(originObj);
+    expect(copiedObj).toEqual(originObj);
+    expect(copiedObj).not.toBe(originObj);
   });
 
   it('should deeply copy a set', () => {
     const originSet = new Set([1, 2, 3]);
-    const copySet = deepCopy(originSet);
+    const copiedSet = deepCopy(originSet);
 
-    expect(copySet).toEqual(originSet);
-    expect(copySet).not.toBe(originSet);
+    expect(copiedSet).toEqual(originSet);
+    expect(copiedSet).not.toBe(originSet);
   });
 
   it('should deeply copy a map', () => {
@@ -37,9 +29,9 @@ describe('deepCopy', () => {
       ['a', 1],
       ['b', 2],
     ]);
-    const copyMap = deepCopy(originMap);
+    const copiedMap = deepCopy(originMap);
 
-    expect(copyMap).toEqual(originMap);
-    expect(copyMap).not.toBe(originMap);
+    expect(copiedMap).toEqual(originMap);
+    expect(copiedMap).not.toBe(originMap);
   });
 });

--- a/packages/utils/src/common/deepCopy/deepCopy.spec.ts
+++ b/packages/utils/src/common/deepCopy/deepCopy.spec.ts
@@ -8,6 +8,36 @@ describe('deepCopy', () => {
     expect(copiedNum).toBe(originNum);
   });
 
+  it('should deeply copy an array', () => {
+    const originArray = [1, 2, [3, 4]];
+    const copiedArray = deepCopy(originArray);
+
+    expect(copiedArray).toEqual(originArray);
+    expect(copiedArray).not.toBe(originArray);
+  });
+
+  it('should also copy the array circular references deeply.', () => {
+    const originArray: any[] = [];
+    originArray.push(originArray);
+
+    const copiedArr = deepCopy(originArray);
+
+    expect(copiedArr).toEqual(copiedArr[0]);
+    expect(copiedArr).not.toBe(originArray);
+    expect(copiedArr).not.toBe(originArray[0]);
+  });
+
+  it('should also copy the object circular references deeply.', () => {
+    const originObject = { origin: {} };
+    originObject.origin = originObject;
+
+    const copiedObject = deepCopy(originObject);
+
+    expect(copiedObject).toEqual(copiedObject.origin);
+    expect(copiedObject).not.toBe(originObject);
+    expect(copiedObject).not.toBe(originObject.origin);
+  });
+
   it('should deeply copy an object', () => {
     const originObj = { a: 1, b: { c: 2 } };
     const copiedObj = deepCopy(originObj);
@@ -33,5 +63,22 @@ describe('deepCopy', () => {
 
     expect(copiedMap).toEqual(originMap);
     expect(copiedMap).not.toBe(originMap);
+  });
+
+  it('should deeply copy a date', () => {
+    const date = new Date();
+    const copiedDate = deepCopy(date);
+
+    expect(copiedDate.getTime()).toEqual(date.getTime());
+    expect(copiedDate).not.toBe(date);
+  });
+
+  it('should deeply copy a regex', () => {
+    const regex = /test/gi;
+    const copiedRegex = deepCopy(regex);
+
+    expect(copiedRegex.source).toEqual(regex.source);
+    expect(copiedRegex.flags).toEqual(regex.flags);
+    expect(copiedRegex).not.toBe(regex);
   });
 });

--- a/packages/utils/src/common/deepCopy/index.ts
+++ b/packages/utils/src/common/deepCopy/index.ts
@@ -71,7 +71,7 @@ export const deepCopy = <T>(value: T) => {
       }
     }
 
-    return copyWthRecursion(target) as T;
+    return newObject as T;
   };
 
   return copyWthRecursion(value);

--- a/packages/utils/src/common/deepCopy/index.ts
+++ b/packages/utils/src/common/deepCopy/index.ts
@@ -3,7 +3,7 @@ import { hasProperty } from '../../validator';
 export const deepCopy = <T>(value: T) => {
   const referenceMap = new WeakMap();
 
-  const deepClone = (target: T): T => {
+  const copyWthRecursion = (target: T): T => {
     // Primitive Type
     if (typeof target !== 'object' || target === null) {
       return target;
@@ -20,7 +20,7 @@ export const deepCopy = <T>(value: T) => {
 
       referenceMap.set(target, newArray);
       for (const item of target) {
-        newArray.push(deepClone(item));
+        newArray.push(copyWthRecursion(item));
       }
       return newArray as T;
     }
@@ -31,7 +31,7 @@ export const deepCopy = <T>(value: T) => {
 
       referenceMap.set(target, newSet);
       for (const item of target) {
-        newSet.add(deepClone(item));
+        newSet.add(copyWthRecursion(item));
       }
       return newSet as T;
     }
@@ -42,7 +42,7 @@ export const deepCopy = <T>(value: T) => {
 
       referenceMap.set(target, newMap);
       for (const [key, value] of target) {
-        newMap.set(deepClone(key), deepClone(value));
+        newMap.set(copyWthRecursion(key), copyWthRecursion(value));
       }
       return newMap as T;
     }
@@ -65,12 +65,14 @@ export const deepCopy = <T>(value: T) => {
     referenceMap.set(target, newObject);
     for (const key in target) {
       if (hasProperty(target, key)) {
-        newObject[key] = deepClone((target as Record<PropertyKey, any>)[key]);
+        newObject[key] = copyWthRecursion(
+          (target as Record<PropertyKey, any>)[key]
+        );
       }
     }
 
-    return deepClone(target) as T;
+    return copyWthRecursion(target) as T;
   };
 
-  return deepClone(value);
+  return copyWthRecursion(value);
 };

--- a/packages/utils/src/common/deepCopy/index.ts
+++ b/packages/utils/src/common/deepCopy/index.ts
@@ -57,7 +57,7 @@ export const deepCopy = <T>(source: T, map = new WeakMap()): T => {
   clone = Object.create(Object.getPrototypeOf(source));
   map.set(source, clone);
   for (const key in source) {
-    if (Object.prototype.hasOwnProperty.call(source, key)) {
+    if (hasProperty(source, key)) {
       clone[key] = deepCopy((source as Record<string, any>)[key], map);
     }
   }


### PR DESCRIPTION
## Overview

<!-- Write a description of your work.  -->

- 자신을 참조하는 데이터를 deepCopy했을 때 maximum call stack 이슈가 발생하던 것을 해결했습니다.
- `Date`, `Regex` 타입의 간단한 깊은 복사 테스트 코드를 추가했습니다.
- 복사된 값을 할당하는 변수명이 동사로 되어있어 수정했습니다.

![image](https://github.com/modern-agile-team/modern-kit/assets/78959175/0a3fa7dd-18f5-4551-92b2-53854e0e2ac8)

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)