### PR TITLE
feat(react): OutsideClick 컴포넌트 구현

### DIFF
--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -14,7 +14,7 @@ import { OutsideClick } from '@modern-kit/react';
 <br />
 
 ## Code
-추후 작성 예정
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/OutsideClick/index.tsx)
 
 ## Interface
 ```ts title="typescript"
@@ -46,9 +46,8 @@ type AllowedTagName<Tag extends ElementType> =
     ? HTMLElementTagNameMap[Tag]
     : HTMLElement;
 
-type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
-  ComponentProps<Tag>
-> &
+type OutsideClickProp<Tag extends ElementType> = 
+  ComponentProps<Tag> &
   AsRequired<Tag> &
   NoChildren<Tag> & {
     callback: () => void;
@@ -56,7 +55,6 @@ type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
 
 const OutsideClick: <
   Tag extends ElementType = 'div',
-  E extends AllowedTagName<Tag> = AllowedTagName<Tag>
 >({
   as,
   children,

--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -18,12 +18,46 @@ import { OutsideClick } from '@modern-kit/react';
 
 ## Interface
 ```ts title="typescript"
-type OutsideClickProp<Tag extends React.ElementType> = React.ComponentProps<Tag> & { children: React.ReactNode } & {
-  as?: Tag;
-  callback: () => void;
-};
+type NonHaveChildElements =
+  | 'input'
+  | 'textarea'
+  | 'img'
+  | 'br'
+  | 'hr'
+  | 'meta'
+  | 'link'
+  | 'base'
+  | 'col'
+  | 'embed'
+  | 'source'
+  | 'track'
+  | 'wbr';
 
-const OutsideClick: <E extends HTMLElement = HTMLDivElement, Tag extends ElementType = 'div'>({
+type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
+  ? { children?: never }
+  : { children: ReactNode };
+
+type AsRequired<Tag extends ElementType> = Tag extends 'div'
+  ? { as?: Tag }
+  : { as: Tag };
+
+type AllowedTagName<Tag extends ElementType> =
+  Tag extends keyof HTMLElementTagNameMap
+    ? HTMLElementTagNameMap[Tag]
+    : HTMLElement;
+
+type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
+  ComponentProps<Tag>
+> &
+  AsRequired<Tag> &
+  NoChildren<Tag> & {
+    callback: () => void;
+  };
+
+const OutsideClick: <
+  Tag extends ElementType = 'div',
+  E extends AllowedTagName<Tag> = AllowedTagName<Tag>
+>({
   as,
   children,
   callback,
@@ -32,11 +66,13 @@ const OutsideClick: <E extends HTMLElement = HTMLDivElement, Tag extends Element
 ```
 
 ## Usage
+
+### Default Usage
+
 ```tsx title="typescript"
 import { OutsideClick } from '@modern-kit/react';
 
-
-const Example = () => {
+const DefaultExample = () => {
   return (
      <>
       <OutsideClick callback={() => alert('Outside Clicked!')}>
@@ -48,18 +84,42 @@ const Example = () => {
 };
 ```
 
-export const Example = () => {
+export const DefaultExample = () => {
   return (
-    <OutsideClick<HTMLInputElement, 'input'>
-      callback={() => {
-        console.log('outside clicked!');
-      }}
-      // input disabled
-      disabled
-    >
-      Inside
-    </OutsideClick>
+     <>
+      <OutsideClick callback={() => alert('Outside Clicked!')}>
+        Inside
+      </OutsideClick>
+      <div>Click me</div>
+    </>
   );
 };
 
 <Example />
+
+### Add Other Tags Attributes Usage (Iput Example)
+
+```tsx title="typescript"
+export const InputExmaple = () {
+  return (
+    <OutsideClick<'input'>
+      callback={() => console.log('outside clicked')}
+      as="input"
+      disabled
+    />
+  );
+}
+```
+
+
+export const InputExmaple = () {
+  return (
+    <OutsideClick<'input'>
+      callback={() => console.log('outside clicked')}
+      as="input"
+      disabled
+    />
+  );
+}
+
+<InputExample />

--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -67,12 +67,10 @@ const OutsideClick: <
 
 ## Usage
 
-### Default Usage
-
 ```tsx title="typescript"
 import { OutsideClick } from '@modern-kit/react';
 
-const DefaultExample = () => {
+const Example = () => {
   return (
      <>
       <OutsideClick callback={() => alert('Outside Clicked!')}>
@@ -84,7 +82,7 @@ const DefaultExample = () => {
 };
 ```
 
-export const DefaultExample = () => {
+export const Example = () => {
   return (
      <>
       <OutsideClick callback={() => alert('Outside Clicked!')}>

--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -96,30 +96,3 @@ export const DefaultExample = () => {
 };
 
 <Example />
-
-### Add Other Tags Attributes Usage (Iput Example)
-
-```tsx title="typescript"
-export const InputExmaple = () {
-  return (
-    <OutsideClick<'input'>
-      callback={() => console.log('outside clicked')}
-      as="input"
-      disabled
-    />
-  );
-}
-```
-
-
-export const InputExmaple = () {
-  return (
-    <OutsideClick<'input'>
-      callback={() => console.log('outside clicked')}
-      as="input"
-      disabled
-    />
-  );
-}
-
-<InputExample />

--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -48,8 +48,7 @@ const Example = () => {
 };
 ```
 
-```tsx title="typescript"
-export const Example2 = () => {
+export const Example = () => {
   return (
     <OutsideClick<HTMLInputElement, 'input'>
       callback={() => {
@@ -62,6 +61,5 @@ export const Example2 = () => {
     </OutsideClick>
   );
 };
-```
 
 <Example />

--- a/docs/docs/react/components/OutsideClick.mdx
+++ b/docs/docs/react/components/OutsideClick.mdx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { OutsideClick } from '@modern-kit/react';
+
+# OutsideClick
+
+`useOutsideClickEffect`의 기능을 선언적으로 처리하는 컴포넌트입니다.
+
+`OutsideClick`로 감싸진 컴포넌트 외부를 클릭하는 경우 `callback`이 실행됩니다.
+
+```tsx
+<OutsideClick callback={callback}>{children}</OutsideClick>
+```
+
+<br />
+
+## Code
+추후 작성 예정
+
+## Interface
+```ts title="typescript"
+type OutsideClickProp<Tag extends React.ElementType> = React.ComponentProps<Tag> & { children: React.ReactNode } & {
+  as?: Tag;
+  callback: () => void;
+};
+
+const OutsideClick: <E extends HTMLElement = HTMLDivElement, Tag extends ElementType = 'div'>({
+  as,
+  children,
+  callback,
+  ...props
+}: OutsideClickProp<Tag>) => JSX.Element;
+```
+
+## Usage
+```tsx title="typescript"
+import { OutsideClick } from '@modern-kit/react';
+
+
+const Example = () => {
+  return (
+     <>
+      <OutsideClick callback={() => alert('Outside Clicked!')}>
+        Inside
+      </OutsideClick>
+      <div>Click me</div>
+    </>
+  );
+};
+```
+
+```tsx title="typescript"
+export const Example2 = () => {
+  return (
+    <OutsideClick<HTMLInputElement, 'input'>
+      callback={() => {
+        console.log('outside clicked!');
+      }}
+      // input disabled
+      disabled
+    >
+      Inside
+    </OutsideClick>
+  );
+};
+```
+
+<Example />

--- a/packages/react/src/components/OutsideClick/ClickOutside.spec.tsx
+++ b/packages/react/src/components/OutsideClick/ClickOutside.spec.tsx
@@ -1,0 +1,47 @@
+import { waitFor, screen } from '@testing-library/react';
+import { renderSetup } from '../../utils/test/renderSetup';
+import { OutsideClick } from './index';
+
+describe('OutsideClick', () => {
+  it('should call the callback when an event occurs outside the component', async () => {
+    const onEffect = vitest.fn();
+
+    const { user } = renderSetup(
+      <>
+        <OutsideClick callback={onEffect}>
+          <div data-testid="inside">inside</div>
+        </OutsideClick>
+
+        <div data-testid="outside">outside</div>
+      </>
+    );
+
+    await user.click(screen.getByTestId('inside'));
+    expect(onEffect).not.toHaveBeenCalled();
+
+    await user.click(screen.getByTestId('outside'));
+
+    await waitFor(() => {
+      expect(onEffect).toHaveBeenCalledTimes(1);
+    });
+
+    await user.click(document.body);
+
+    await waitFor(() => {
+      expect(onEffect).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('should not call the callback when an event occurs inside the component', async () => {
+    const onEffect = vitest.fn();
+
+    const { user } = renderSetup(
+      <OutsideClick callback={onEffect}>
+        <div data-testid="inside">inside</div>
+      </OutsideClick>
+    );
+
+    await user.click(screen.getByTestId('inside'));
+    expect(onEffect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/OutsideClick/OutsideClick.spec.tsx
+++ b/packages/react/src/components/OutsideClick/OutsideClick.spec.tsx
@@ -16,10 +16,10 @@ describe('OutsideClick', () => {
       </>
     );
 
-    await user.click(screen.getByRole('inside'));
+    await user.click(screen.getByRole('inside-element'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    await user.click(screen.getByRole('outside'));
+    await user.click(screen.getByRole('outside-element'));
 
     await waitFor(() => {
       expect(onEffect).toHaveBeenCalledTimes(1);
@@ -41,7 +41,7 @@ describe('OutsideClick', () => {
       </OutsideClick>
     );
 
-    await user.click(screen.getByRole('inside'));
+    await user.click(screen.getByRole('inside-element'));
     expect(onEffect).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/OutsideClick/OutsideClick.spec.tsx
+++ b/packages/react/src/components/OutsideClick/OutsideClick.spec.tsx
@@ -9,17 +9,17 @@ describe('OutsideClick', () => {
     const { user } = renderSetup(
       <>
         <OutsideClick callback={onEffect}>
-          <div data-testid="inside">inside</div>
+          <div role="inside-element">inside</div>
         </OutsideClick>
 
-        <div data-testid="outside">outside</div>
+        <div role="outside-element">outside</div>
       </>
     );
 
-    await user.click(screen.getByTestId('inside'));
+    await user.click(screen.getByRole('inside'));
     expect(onEffect).not.toHaveBeenCalled();
 
-    await user.click(screen.getByTestId('outside'));
+    await user.click(screen.getByRole('outside'));
 
     await waitFor(() => {
       expect(onEffect).toHaveBeenCalledTimes(1);
@@ -37,11 +37,11 @@ describe('OutsideClick', () => {
 
     const { user } = renderSetup(
       <OutsideClick callback={onEffect}>
-        <div data-testid="inside">inside</div>
+        <div role="inside-element">inside</div>
       </OutsideClick>
     );
 
-    await user.click(screen.getByTestId('inside'));
+    await user.click(screen.getByRole('inside'));
     expect(onEffect).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/components/OutsideClick/index.tsx
+++ b/packages/react/src/components/OutsideClick/index.tsx
@@ -42,7 +42,7 @@ type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
     callback: () => void;
   };
 
-export default function OutsideClick<
+export function OutsideClick<
   Tag extends ElementType = 'div',
   E extends AllowedTagName<Tag> = AllowedTagName<Tag>
 >({ as, children, callback, ...props }: OutsideClickProp<Tag>) {

--- a/packages/react/src/components/OutsideClick/index.tsx
+++ b/packages/react/src/components/OutsideClick/index.tsx
@@ -1,16 +1,50 @@
-import { ComponentProps, ElementType, ReactNode } from 'react';
+import {
+  ComponentProps,
+  ElementType,
+  ReactNode,
+  PropsWithChildren,
+} from 'react';
 import { useOnClickOutside } from '../../hooks/useOnClickOutside';
 
-type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> & {
-  children: ReactNode;
-} & {
-  as?: Tag;
-  callback: () => void;
-};
+type NonHaveChildElements =
+  | 'input'
+  | 'textarea'
+  | 'img'
+  | 'br'
+  | 'hr'
+  | 'meta'
+  | 'link'
+  | 'base'
+  | 'col'
+  | 'embed'
+  | 'source'
+  | 'track'
+  | 'wbr';
 
-export function OutsideClick<
-  E extends HTMLElement = HTMLDivElement,
-  Tag extends ElementType = 'div'
+type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
+  ? { children?: never }
+  : { children?: ReactNode };
+
+type AsRequired<Tag extends ElementType> = Tag extends 'div'
+  ? { as?: Tag }
+  : { as: Tag };
+
+type AllowedTagName<Tag extends ElementType> =
+  Tag extends keyof HTMLElementTagNameMap
+    ? HTMLElementTagNameMap[Tag]
+    : HTMLElement;
+
+type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
+  ComponentProps<Tag>
+> &
+  AsRequired<Tag> &
+  NoChildren<Tag> & {
+    callback: () => void;
+  };
+
+export default function OutsideClick<
+  Tag extends ElementType = 'div',
+  E extends AllowedTagName<Tag> = AllowedTagName<Tag>
 >({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
   const { ref } = useOnClickOutside<E>(callback);
 

--- a/packages/react/src/components/OutsideClick/index.tsx
+++ b/packages/react/src/components/OutsideClick/index.tsx
@@ -1,0 +1,24 @@
+import { ComponentProps, ElementType, ReactNode } from 'react';
+import { useOnClickOutside } from '../../hooks/useOnClickOutside';
+
+type OutsideClickProp<Tag extends ElementType> = ComponentProps<Tag> & {
+  children: ReactNode;
+} & {
+  as?: Tag;
+  callback: () => void;
+};
+
+export function OutsideClick<
+  E extends HTMLElement = HTMLDivElement,
+  Tag extends ElementType = 'div'
+>({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
+  const { ref } = useOnClickOutside<E>(callback);
+
+  const Component = as || 'div';
+
+  return (
+    <Component ref={ref} {...props}>
+      {children}
+    </Component>
+  );
+}

--- a/packages/react/src/components/OutsideClick/index.tsx
+++ b/packages/react/src/components/OutsideClick/index.tsx
@@ -23,7 +23,7 @@ type NonHaveChildElements =
 
 type NoChildren<Tag extends ElementType> = Tag extends NonHaveChildElements
   ? { children?: never }
-  : { children?: ReactNode };
+  : { children: ReactNode };
 
 type AsRequired<Tag extends ElementType> = Tag extends 'div'
   ? { as?: Tag }
@@ -42,10 +42,15 @@ type OutsideClickProp<Tag extends ElementType> = PropsWithChildren<
     callback: () => void;
   };
 
-export function OutsideClick<
+export const OutsideClick = <
   Tag extends ElementType = 'div',
   E extends AllowedTagName<Tag> = AllowedTagName<Tag>
->({ as, children, callback, ...props }: OutsideClickProp<Tag>) {
+>({
+  as,
+  children,
+  callback,
+  ...props
+}: OutsideClickProp<Tag>) => {
   const { ref } = useOnClickOutside<E>(callback);
 
   const Component = as || 'div';
@@ -55,4 +60,4 @@ export function OutsideClick<
       {children}
     </Component>
   );
-}
+};

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -4,3 +4,4 @@ export * from './LazyImage';
 export * from './Portal';
 export * from './When';
 export * from './SwitchCase';
+export * from './OutsideClick';

--- a/packages/react/src/hooks/useOnClickOutside/index.ts
+++ b/packages/react/src/hooks/useOnClickOutside/index.ts
@@ -11,10 +11,10 @@ export const useOnClickOutside = <T extends HTMLElement>(
   useEffect(() => {
     const eventType = isMobile() ? 'touchstart' : 'mousedown';
 
-    const listener = (e: MouseEvent | TouchEvent) => {
+    const listener = ({ target }: MouseEvent | TouchEvent) => {
       const targetElement = ref.current;
 
-      if (targetElement && !targetElement.contains(e.target as Node)) {
+      if (targetElement && !targetElement.contains(target as Node)) {
         callbackAction(targetElement);
       }
     };


### PR DESCRIPTION
## AS-IS

```jsx
const { ref } = useOnClickOutside(callback);
return <div ref={ref}>inside</div>;
```

## TO-BE

```jsx
<OutsideClick callback={() => console.log('outside clicked!')}>
  <div>something</div>
</OutsideClick>
```

<br/>

## Overview

A component that declaratively handles the functionality of `useOnClickOutside`.
If you click outside the component wrapped in `OutsideClick`, `callback` is executed.

```jsx
<OutsideClick callback={callback}>{children}</OutsideClick>
```

## Attributes

Assign an `ElementType` to `<OutsideClick>`.
Use `HTMLAttributes` as needed.

```jsx
function Component() {
  return (
    <OutsideClick<'input'>
      as='input'
      callback={() => {
        console.log('outside clicked!');
      }}
    />
  );
}
```

- Documentation completed. (73532b4078cddbbd2185f78a3a789c820df9365b)
- Test code completed. (92e652ae8dab2278a8a8d419d945df09d7f26f55)

close #162 

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)

<br/>
