### PR TITLE
feat(utils): delay 인자 음수, NaN 검증 추가

### DIFF
--- a/.changeset/slimy-coats-obey.md
+++ b/.changeset/slimy-coats-obey.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/utils": patch
+---
+
+feat(utils): delay 인자 음수, NaN 검증 추가 - @hoonloper

--- a/packages/utils/src/common/delay/delay.spec.ts
+++ b/packages/utils/src/common/delay/delay.spec.ts
@@ -12,4 +12,12 @@ describe('delay', () => {
 
     expect(end - start).toBeGreaterThanOrEqual(time);
   });
+
+  it('should reject with negative time', async () => {
+    await expect(delay(-100)).rejects.toThrow('Invalid time value');
+  });
+
+  it('should reject with NaN time', async () => {
+    await expect(delay(NaN)).rejects.toThrow('Invalid time value');
+  });
 });

--- a/packages/utils/src/common/delay/index.ts
+++ b/packages/utils/src/common/delay/index.ts
@@ -1,5 +1,7 @@
-export const delay = (time: number) => {
-  return new Promise<void>((resolve) => {
-    setTimeout(() => resolve(), time);
+export const delay = (time: number): Promise<void> => {
+  return new Promise<void>((resolve, reject) => {
+    if (isNaN(time) || time < 0) reject(new Error('Invalid time value'));
+
+    setTimeout(resolve, time);
   });
 };


### PR DESCRIPTION
## Overview
- delay 함수 인자로 받는 `time`에 대한 NaN, 음수 검증을 추가했습니다.
- 예외에 대한 처리가 애매한데 좋은 방법이 있을까요? 현재는 `new Error("Invalid time value")`를 던지고 있는데 더 적합한 방식이 있으면 의견 부탁드립니다!
<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)