### PR TITLE
feat(utils): rem 신규 유틸 함수 추가

### DIFF
--- a/.changeset/stale-mangos-suffer.md
+++ b/.changeset/stale-mangos-suffer.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): rem 신규 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/style/rem.md
+++ b/docs/docs/utils/style/rem.md
@@ -21,12 +21,12 @@ rem(17, { toFixedDigits: 10 }); // 1.0625
 
 ## Interface
 ```ts title="typescript"
-interface RemOption {
+interface RemOptions {
   suffix?: boolean; // default: false
   toFixedDigits?: number;
 }
 
-const rem: (pixel: number, options?: RemOption) => string | number;
+const rem: (pixel: number, options?: RemOptions) => string | number;
 ```
 
 ## Usage

--- a/docs/docs/utils/style/rem.md
+++ b/docs/docs/utils/style/rem.md
@@ -1,0 +1,52 @@
+# rem
+
+`Root 요소(html)`의 `fontSize`를 기반으로 `pixel` 값을 `rem` 형태로 변환해주는 유틸 함수입니다.
+
+`suffix`옵션을 통해서 계산한 rem 값에 접미사로 `"rem"`을 붙여서 반환시킬 수 있습니다.
+
+`toFixedDigits` 옵션을 통해서 `고정 소수점 표기법(fixed-point notation)`으로 표시할 수 있습니다. 단, 불 필요한 소수점을 버리기 위해 `한번 더 숫자로 변환 후 반환`합니다.
+
+```ts title="typescript"
+// as-is
+(1.0625).toFixed(10); // '1.0625000000'
+
+// to-be
+rem(17, { toFixedDigits: 10 }); // 1.0625
+```
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/style/rem/index.ts)
+
+## Interface
+```ts title="typescript"
+interface RemOption {
+  suffix?: boolean; // default: false
+  toFixedDigits?: number;
+}
+
+const rem: (pixel: number, options?: RemOption) => string | number;
+```
+
+## Usage
+```ts title="typescript"
+import { rem } from '@modern-kit/utils';
+
+// Root FontSize: 16px;
+rem(16); // 1;
+rem(24); // 1.5;
+rem(32); // 2;
+
+// Suffix
+rem(16, { suffix: true }); // "1rem";
+rem(24, { suffix: true }); // "1.5rem";
+rem(32, { suffix: true }); // "2rem";
+
+// ToFixedDigits
+rem(17); // 1.0625
+rem(17, { toFixedDigits: 2 }); // 1.06
+rem(17, { toFixedDigits: 3 }); // 1.063
+rem(17, { toFixedDigits: 4 }); // 1.0625
+rem(17, { toFixedDigits: 10 }); // 1.0625
+```

--- a/docs/docs/utils/validator/hasProperty.md
+++ b/docs/docs/utils/validator/hasProperty.md
@@ -16,7 +16,7 @@ const hasProperty: <T extends Record<PropertyKey, any>, K extends PropertyKey>(
 ```
 
 ## Usage
-```ts
+```ts title="typescript"
 import { hasProperty } from '@modern-kit/utils';
 
 const exampleObj = { foo: 'foo', bar: 'bar' } as const;

--- a/packages/react/src/hooks/useHover/useHover.spec.tsx
+++ b/packages/react/src/hooks/useHover/useHover.spec.tsx
@@ -1,6 +1,6 @@
 import { useHover } from '.';
 import { renderSetup } from '../../utils/test/renderSetup';
-import { screen } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { Mock } from 'vitest';
 
 describe('useHover', () => {
@@ -31,7 +31,7 @@ describe('useHover', () => {
     const leaveMockFn = vi.fn();
 
     const { user } = renderSetup(
-      <TestComponent enterMockFn={enterMockFn} leaveMockFn={leaveMockFn} />,
+      <TestComponent enterMockFn={enterMockFn} leaveMockFn={leaveMockFn} />
     );
 
     const hoverTarget = screen.getByRole('hover-target');
@@ -51,17 +51,21 @@ describe('useHover', () => {
     const hoverTarget = screen.getByRole('hover-target');
 
     expect(
-      screen.queryByRole('conditional-render-text'),
+      screen.queryByRole('conditional-render-text')
     ).not.toBeInTheDocument();
 
     await user.hover(hoverTarget);
 
-    expect(screen.queryByRole('conditional-render-text')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('conditional-render-text')).toBeInTheDocument();
+    });
 
     await user.unhover(hoverTarget);
 
-    expect(
-      screen.queryByRole('conditional-render-text'),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('conditional-render-text')
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -7,4 +7,5 @@ export * from './file';
 export * from './object';
 export * from './storage';
 export * from './string';
+export * from './style';
 export * from './validator';

--- a/packages/utils/src/style/index.ts
+++ b/packages/utils/src/style/index.ts
@@ -1,0 +1,1 @@
+export * from './rem';

--- a/packages/utils/src/style/rem/index.ts
+++ b/packages/utils/src/style/rem/index.ts
@@ -1,7 +1,7 @@
 import { isNumber } from '../../validator';
 import { isClient } from '../../device';
 
-interface RemOption {
+interface RemOptions {
   suffix?: boolean;
   toFixedDigits?: number;
 }
@@ -13,7 +13,7 @@ const getFixedRem = (rem: number, toFixedDigits?: number) => {
   return rem;
 };
 
-export const rem = (pixel: number, options: RemOption = {}) => {
+export const rem = (pixel: number, options: RemOptions = {}) => {
   if (!isClient()) {
     throw new Error('Cannot be executed unless it is a client environment.');
   }

--- a/packages/utils/src/style/rem/index.ts
+++ b/packages/utils/src/style/rem/index.ts
@@ -1,0 +1,31 @@
+import { isNumber } from '../../validator';
+import { isClient } from '../../device';
+
+interface RemOption {
+  suffix?: boolean;
+  toFixedDigits?: number;
+}
+
+const getFixedRem = (rem: number, toFixedDigits?: number) => {
+  if (isNumber(toFixedDigits)) {
+    return Number(rem.toFixed(toFixedDigits));
+  }
+  return rem;
+};
+
+export const rem = (pixel: number, options: RemOption = {}) => {
+  if (!isClient()) {
+    throw new Error('Cannot be executed unless it is a client environment.');
+  }
+  const { suffix = false, toFixedDigits } = options;
+
+  const rootElement = document.documentElement;
+  const rootFontSize = parseFloat(getComputedStyle(rootElement).fontSize); // "16px" -> 16
+
+  const fixedRem = getFixedRem(pixel / rootFontSize, toFixedDigits);
+
+  if (suffix) {
+    return `${fixedRem}rem`;
+  }
+  return fixedRem;
+};

--- a/packages/utils/src/style/rem/rem.spec.ts
+++ b/packages/utils/src/style/rem/rem.spec.ts
@@ -1,0 +1,60 @@
+import { MockInstance } from 'vitest';
+import { rem } from '.';
+
+const originWindow = globalThis.window;
+let getComputedStyleSpy: MockInstance;
+
+beforeEach(() => {
+  getComputedStyleSpy = vi.spyOn(window, 'getComputedStyle');
+  getComputedStyleSpy.mockReturnValue({ fontSize: '16px' });
+});
+
+afterEach(() => {
+  globalThis.window = originWindow;
+  getComputedStyleSpy.mockRestore();
+});
+
+describe('rem', () => {
+  it('should convert pixels to rem without any options. (Root FontSize: 16px)', () => {
+    expect(rem(16)).toBe(1);
+    expect(rem(24)).toBe(1.5);
+    expect(rem(32)).toBe(2);
+  });
+
+  it('should convert pixels to rem without any options. (Root FontSize: 24px)', () => {
+    getComputedStyleSpy.mockReturnValue({ fontSize: '24px' });
+
+    expect(rem(24)).toBe(1);
+    expect(rem(30)).toBe(1.25);
+    expect(rem(36)).toBe(1.5);
+  });
+
+  it('should convert pixels to rem and add "rem" suffix. (Root FontSize: 16px)', () => {
+    expect(rem(16, { suffix: true })).toBe('1rem');
+    expect(rem(24, { suffix: true })).toBe('1.5rem');
+    expect(rem(32, { suffix: true })).toBe('2rem');
+  });
+
+  it('should convert pixels to rem with fixed decimal places. (Root FontSize: 16px)', () => {
+    expect(rem(17)).toBe(1.0625);
+
+    expect(rem(17, { toFixedDigits: 0 })).toBe(1); // toFixed Default behavior
+    expect(rem(17, { toFixedDigits: NaN })).toBe(1); // toFixed Default behavior
+    expect(rem(17, { toFixedDigits: 1 })).toBe(1.1);
+    expect(rem(17, { toFixedDigits: 2 })).toBe(1.06);
+    expect(rem(17, { toFixedDigits: 3 })).toBe(1.063);
+    expect(rem(17, { toFixedDigits: 4 })).toBe(1.0625);
+    expect(rem(17, { toFixedDigits: 10 })).toBe(1.0625);
+  });
+
+  it('should throw an error if toFixedDigits is out of range.', () => {
+    expect(() => rem(16, { toFixedDigits: -1 })).toThrowError();
+    expect(() => rem(16, { toFixedDigits: 101 })).toThrowError();
+  });
+
+  it('should throw an error if not executed in a client environment.', () => {
+    globalThis.window = undefined as any;
+
+    expect(() => rem(16)).toThrowError();
+  });
+});


### PR DESCRIPTION
## Overview

`Root 요소(html)`의 `fontSize`를 기반으로 `pixel` 값을 `rem` 형태로 변환해주는 유틸 함수입니다.
`css in js` 환경 등에서 유용하게 활용할 수 있습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)