### PR TITLE
fix(react): useInterval enabled 속성 추가

### DIFF
--- a/.changeset/olive-flies-hope.md
+++ b/.changeset/olive-flies-hope.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+fix(react): useInterval enabled 속성 추가 - @ssi02014

--- a/docs/docs/react/hooks/useInterval.mdx
+++ b/docs/docs/react/hooks/useInterval.mdx
@@ -5,11 +5,9 @@ import { useState } from 'react';
 
 `window.setInterval`을 편리하게 사용할 수 있는 커스텀 훅입니다. 
 
-`window.setInterva`과 `useInterval` 훅의 주요 차이점은 그 인수가 `동적`이라는 것입니다.
+2번째 인자 options는 `number` 혹은 `{ delay: SetIntervalParameters[1]; enabled?: boolean }` 타입의 객체를 넘겨 줄 수 있습니다.
 
-2번째 인자 options는 `number` 혹은 `{ delay: SetIntervalParameters[1]; enabled?: boolean }` 타입의 객체를 받아올 수 있습니다.
-
-number타입이면 해당 값은 `setInterval`의 `delay` 값이 되며, 객체 타입일 경우 `delay`와 더불어 `setInterval의 동작 여부`를 결정하는 `enabled` 옵션을 추가로 다룰 수 있습니다. 
+options가 `number` 타입이면 해당 값은 `setInterval`의 `delay` 값이 되며, 객체 타입일 경우 delay와 더불어 `setInterval의 동작 여부`를 결정하는 `enabled` 옵션을 추가로 다룰 수 있습니다. 
   - 💡 options가 number 타입의 경우 enabled는 기본적으로 `true`입니다.
 
 ```ts

--- a/docs/docs/react/hooks/useInterval.mdx
+++ b/docs/docs/react/hooks/useInterval.mdx
@@ -7,7 +7,15 @@ import { useState } from 'react';
 
 `window.setInterva`과 `useInterval` 훅의 주요 차이점은 그 인수가 `동적`이라는 것입니다.
 
-3번째 인자 options의 `enabled` 옵션을 통해 interval 동작을 조절 할 수 있습니다.
+2번째 인자 options는 `number` 혹은 `{ delay: SetIntervalParameters[1]; enabled?: boolean }` 타입의 객체를 받아올 수 있습니다.
+
+number타입이면 해당 값은 `setInterval`의 `delay` 값이 되며, 객체 타입일 경우 `delay`와 더불어 `setInterval의 동작 여부`를 결정하는 `enabled` 옵션을 추가로 다룰 수 있습니다. 
+  - 💡 options가 number 타입의 경우 enabled는 기본적으로 `true`입니다.
+
+```ts
+useInterval(callback, 500);
+useInterval(callback, { delay: 500, enabled: true });
+```
 
 <br />
 
@@ -18,14 +26,13 @@ import { useState } from 'react';
 ```ts title="typescript"
 type SetIntervalParameters = Parameters<typeof setInterval>;
 
-interface UseIntervalOptions {
-  enabled?: boolean; // default: true
-}
+type IntervalOptions =
+  | number
+  | { delay: SetIntervalParameters[1]; enabled?: boolean };
 
 const useInterval: (
   callback: SetIntervalParameters[0],
-  delay?: SetIntervalParameters[1],
-  options?: UseIntervalOptions
+  options: IntervalOptions
 ) => void;
 ```
 
@@ -37,27 +44,33 @@ const Example = () => {
   const [number, setNumber] = useState(0);
   const [isToggle, setIsToggle] = useState(true);
 
-  useInterval(() => setNumber(number + 1), 500, { enabled: isToggle });
+  useInterval(() => setNumber(number + 1), { delay: 1000, enabled: isToggle });
 
   return (
     <div>
       <div>{number}</div>
-      <button onClick={() => setIsToggle(!isToggle)}>{isToggle ? "멈추기" : "시작하기"}</button>
+      <button onClick={() => setIsToggle(!isToggle)}>
+        {isToggle ? '멈추기' : '시작하기'}
+      </button>
     </div>
   );
 };
+
 ```
 
 export const Example = () => {
   const [number, setNumber] = useState(0);
   const [isToggle, setIsToggle] = useState(true);
-  useInterval(() => setNumber(number + 1), 1000, { enabled: isToggle });
+  useInterval(() => setNumber(number + 1), { delay: 1000, enabled: isToggle });
   return (
     <div>
       <div>{number}</div>
-      <button onClick={() => setIsToggle(!isToggle)}>{isToggle ? "멈추기" : "시작하기"}</button>
+      <button onClick={() => setIsToggle(!isToggle)}>
+        {isToggle ? '멈추기' : '시작하기'}
+      </button>
     </div>
   );
 };
+
 
 <Example />

--- a/docs/docs/react/hooks/useInterval.mdx
+++ b/docs/docs/react/hooks/useInterval.mdx
@@ -1,10 +1,13 @@
+import { useInterval } from '@modern-kit/react';
+import { useState } from 'react';
+
 # useInterval
 
 `window.setInterval`을 편리하게 사용할 수 있는 커스텀 훅입니다. 
 
 `window.setInterva`과 `useInterval` 훅의 주요 차이점은 그 인수가 `동적`이라는 것입니다.
 
-`delay`의 값으로 `null`을 넣으면 타이머를 중지할 수 있습니다.
+3번째 인자 options의 `enabled` 옵션을 통해 interval 동작을 조절 할 수 있습니다.
 
 <br />
 
@@ -15,7 +18,15 @@
 ```ts title="typescript"
 type SetIntervalParameters = Parameters<typeof setInterval>;
 
-const useInterval: (callback: SetIntervalParameters[0], delay?: SetIntervalParameters[1]) => void
+interface UseIntervalOptions {
+  enabled?: boolean; // default: true
+}
+
+const useInterval: (
+  callback: SetIntervalParameters[0],
+  delay?: SetIntervalParameters[1],
+  options?: UseIntervalOptions
+) => void;
 ```
 
 ## Usage
@@ -24,15 +35,29 @@ import { useInterval } from '@modern-kit/react';
 
 const Example = () => {
   const [number, setNumber] = useState(0);
-  const [isPlaying, setIsPlaying] = useState(true);
+  const [isToggle, setIsToggle] = useState(true);
 
-  useInterval(() => setNumber(number + 1), 1000);
+  useInterval(() => setNumber(number + 1), 500, { enabled: isToggle });
 
   return (
     <div>
       <div>{number}</div>
-      <button onClick={() => setIsPlaying(false)}>button</button>
+      <button onClick={() => setIsToggle(!isToggle)}>{isToggle ? "멈추기" : "시작하기"}</button>
     </div>
   );
 };
 ```
+
+export const Example = () => {
+  const [number, setNumber] = useState(0);
+  const [isToggle, setIsToggle] = useState(true);
+  useInterval(() => setNumber(number + 1), 1000, { enabled: isToggle });
+  return (
+    <div>
+      <div>{number}</div>
+      <button onClick={() => setIsToggle(!isToggle)}>{isToggle ? "멈추기" : "시작하기"}</button>
+    </div>
+  );
+};
+
+<Example />

--- a/packages/react/src/hooks/useInterval/index.ts
+++ b/packages/react/src/hooks/useInterval/index.ts
@@ -1,18 +1,19 @@
+import { isNumber } from '@modern-kit/utils';
 import { usePreservedCallback } from '../usePreservedCallback';
 import { useEffect } from 'react';
 
 type SetIntervalParameters = Parameters<typeof setInterval>;
 
-interface UseIntervalOptions {
-  enabled?: boolean;
-}
+type IntervalOptions =
+  | number
+  | { delay: SetIntervalParameters[1]; enabled?: boolean };
 
 export const useInterval = (
   callback: SetIntervalParameters[0],
-  delay?: SetIntervalParameters[1],
-  options: UseIntervalOptions = {}
+  options: IntervalOptions
 ) => {
-  const { enabled = true } = options;
+  const delay = isNumber(options) ? options : options.delay;
+  const enabled = isNumber(options) ? true : options?.enabled ?? true;
 
   const callbackAction = usePreservedCallback(callback);
 
@@ -20,8 +21,11 @@ export const useInterval = (
     if (delay == null) return;
 
     const intervalId = window.setInterval(() => {
-      if (!enabled) clearInterval(intervalId);
-      callbackAction();
+      if (!enabled) {
+        clearInterval(intervalId);
+      } else {
+        callbackAction();
+      }
     }, delay);
 
     return () => clearInterval(intervalId);

--- a/packages/react/src/hooks/useInterval/index.ts
+++ b/packages/react/src/hooks/useInterval/index.ts
@@ -3,19 +3,27 @@ import { useEffect } from 'react';
 
 type SetIntervalParameters = Parameters<typeof setInterval>;
 
+interface UseIntervalOptions {
+  enabled?: boolean;
+}
+
 export const useInterval = (
   callback: SetIntervalParameters[0],
-  delay?: SetIntervalParameters[1]
+  delay?: SetIntervalParameters[1],
+  options: UseIntervalOptions = {}
 ) => {
+  const { enabled = true } = options;
+
   const callbackAction = usePreservedCallback(callback);
 
   useEffect(() => {
-    if (delay == null) {
-      return;
-    }
+    if (delay == null) return;
 
-    const intervalId = window.setInterval(callbackAction, delay);
+    const intervalId = window.setInterval(() => {
+      if (!enabled) clearInterval(intervalId);
+      callbackAction();
+    }, delay);
 
     return () => clearInterval(intervalId);
-  }, [callbackAction, delay]);
+  }, [callbackAction, enabled, delay]);
 };

--- a/packages/react/src/hooks/useInterval/useInterval.spec.tsx
+++ b/packages/react/src/hooks/useInterval/useInterval.spec.tsx
@@ -31,7 +31,7 @@ describe('useInterval', () => {
 
   it('should not run the interval when enabled is false and should run when enabled is true', () => {
     const { rerender } = renderHook(
-      ({ enabled }) => useInterval(mockFn, delayTime, { enabled }),
+      ({ enabled }) => useInterval(mockFn, { delay: delayTime, enabled }),
       {
         initialProps: { enabled: true },
       }
@@ -44,19 +44,16 @@ describe('useInterval', () => {
     rerender({ enabled: false });
 
     vi.advanceTimersByTime(delayTime);
-    expect(mockFn).toBeCalledTimes(1);
-
-    vi.advanceTimersByTime(delayTime);
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).not.toBeCalled();
 
     rerender({ enabled: true });
 
     vi.advanceTimersByTime(delayTime);
-    expect(mockFn).toBeCalledTimes(2);
+    expect(mockFn).toBeCalledTimes(1);
   });
 
   it('should not run the interval if delay is undefined', () => {
-    renderHook(() => useInterval(mockFn, undefined));
+    renderHook(() => useInterval(mockFn, { delay: undefined }));
 
     expect(mockFn).not.toBeCalled();
 


### PR DESCRIPTION
## Overview

useInterval은 사용자가 직접 중간에 Interval을 멈추거나, 다시 동작시키거나 하는 니즈가 있을 수 있기때문에 이를 조절할 수 있게 명시적인 `enabled` 옵션을 추가합니다. 기존 버전과의 호환성을 위해 인터페이스를 많이 수정하기보다 options라는 3번째 인자를 추가하였습니다.

그 외 아래와 같은 작업이 진행됐습니다.
- Test 코드가 개선되었습니다. renderHook만으로 모든 기능 테스트가 가능하므로 컴포넌트를 통한 테스트 코드는 제거하였습니다.
- 실제 실습 예제를 추가하면서 문서를 보완하였습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)