### PR TITLE
feat: coauthor 함수 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -7,7 +7,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
   ],
-  ignorePatterns: ['dist', '.eslintrc.*', 'babel.*'],
+  ignorePatterns: ['dist', '.eslintrc.*', 'babel.*', 'scripts'],
   parser: '@typescript-eslint/parser',
   plugins: ['unused-imports', 'react-refresh'],
   rules: {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "author": "ssi02014 <ssi02014@naver.com>",
   "scripts": {
+    "coauthor": "node scripts/coauthor.js",
     "typecheck": "lerna run typecheck",
     "test": "lerna run test:run",
     "build": "lerna run build && yarn eslint packages && yarn typecheck && yarn test",

--- a/scripts/coauthor.js
+++ b/scripts/coauthor.js
@@ -1,0 +1,40 @@
+// https://docs.github.com/en/rest/users/users?apiVersion=2022-11-28#get-a-user
+const GITHUB_USERS_API_URL = `https://api.github.com/users`;
+
+const getGithubUserInfo = async (userName) => {
+  const res = await fetch(`${GITHUB_USERS_API_URL}/${userName}`);
+  const userInfo = await res.json();
+
+  return [userName, userInfo];
+};
+
+const generateCoAuthorMessage = (userName, userInfo) => {
+  return `Co-authored-by: ${userInfo?.name ?? userName} <${
+    userInfo.id
+  }+${userName}@users.noreply.github.com>`;
+};
+
+/**
+ * @description 공동 작업자(co-author)를 추가하기 위해 쉽게 co-author 메시지를 생성하는 함수입니다.
+ * Github Api를 활용해 "no-reply" 형태의 이메일을 수집 후, 수집한 이메일을 기반으로 co-author 메시지를 생성합니다.
+ *
+ * 공동 작업자(co-author) 추가 방법
+ * - https://docs.github.com/ko/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors
+ *
+ * 실행 방법(터미널)
+ * - yarn coauthor {userName} {userName} {userName} ...
+ * - ex) yarn coauthor ssi02014 Sangminnn
+ */
+const coauthors = async (args) => {
+  const userInfoList = await Promise.all(
+    args.map((userName) => getGithubUserInfo(userName))
+  );
+
+  const messages = userInfoList.map(([userName, userInfo]) =>
+    generateCoAuthorMessage(userName, userInfo)
+  );
+
+  console.log(messages.join('\n'));
+};
+
+coauthors(process.argv.slice(2));


### PR DESCRIPTION
## Overview

최근 공동 작업자를 추가하는 작업을 하면서 각 유저의 `Github Email` 확인에 있어 불편함을 느꼈습니다.
따라서, Github UserName을 기반으로 Github API를 활용해 `no-reply` 형태의 이메일을 수집 후,
이를 활용해 `co-author 메시지`를 생성하는 함수를 작성하였습니다.

터미널에서 아래와 같이 실행 할 수 있습니다.
```shell
yarn coauthor {userName} {userName} {userName} ...
```

```
ex) yarn coauthor ssi02014 Sangminnn

Co-authored-by: Gromit (전민재) <64779472+ssi02014@users.noreply.github.com>
Co-authored-by: Sangminnn <26050574+Sangminnn@users.noreply.github.com>
```
![스크린샷 2024-05-30 오후 11 33 24](https://github.com/modern-agile-team/modern-kit/assets/64779472/28da2771-24ec-4ce4-8546-81b972768a6f)

위와 같이 생성된 co-author message로 손쉽게 공동 작업자를 추가 할 수 있습니다.

## 참고
- [여러 작성자와 커밋 만들기](https://docs.github.com/ko/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors)
- [coauthors](https://github.com/coauthors/coauthors)

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)