### PR TITLE
fix(utils): delay 유틸 함수 개선

### DIFF
--- a/.changeset/eight-colts-press.md
+++ b/.changeset/eight-colts-press.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': patch
+---
+
+fix(utils): delay 유틸 함수 개선 - @ssi02014

--- a/docs/docs/utils/common/delay.md
+++ b/docs/docs/utils/common/delay.md
@@ -2,7 +2,11 @@
 
 주어진 시간만큼 기다린 뒤 다음 동작을 수행할 수 있도록 하는 함수입니다.
 
-setTimeout을 사용하여 특정 시간 뒤의 동작을 정의할 경우, 해당 시간 뒤 동작해야하는 함수 다음에 Promise가 존재한다면 setTimeout은 macroTaskQueue에 속하고 Promise는 microTaskQueue에 속하게 되어 의도한 바와 같이 순서대로의 동작을 보장하지 못할 수 있습니다. delay 함수를 사용한다면 이러한 문제를 해결할 수 있습니다.
+`setTimeout`을 사용하여 특정 시간 뒤의 동작을 정의할 경우, 해당 시간 뒤 동작해야하는 함수 다음에 Promise가 존재한다면 setTimeout은 `macroTaskQueue`에 속하고 Promise는 `microTaskQueue`에 속하게 되어 의도한 바와 같이 순서대로의 동작을 보장하지 못할 수 있습니다. 
+
+delay 함수를 사용한다면 이러한 문제를 해결할 수 있습니다.
+
+2번째 인자로 함수를 넘겨주면, 주어진 시간 후에 해당 함수를 호출 할 수 있습니다.
 
 <br />
 
@@ -11,7 +15,7 @@ setTimeout을 사용하여 특정 시간 뒤의 동작을 정의할 경우, 해�
 
 ## Interface
 ```ts title="typescript"
-const delay: (time: number) => Promise<void>
+const delay: (time: number, callback?: () => void) => Promise<void>;
 ```
 
 ## Usage
@@ -23,5 +27,11 @@ const something = () => Promise.resolve()
 const doSomethingAfterDelay = async () => {
   await delay(1000)
   await something()
-}
+};
+
+const callFuncAfterDelay = async () => {
+  await delay(1000, () => {
+    console.log("test");
+  })
+};
 ```

--- a/packages/utils/src/common/delay/delay.spec.ts
+++ b/packages/utils/src/common/delay/delay.spec.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { delay } from '.';
 
+const time = 200;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 describe('delay', () => {
   it('should delay the promise by the given time', async () => {
-    const time = 200;
     const start = Date.now();
 
     await delay(time);
@@ -13,11 +18,23 @@ describe('delay', () => {
     expect(end - start).toBeGreaterThanOrEqual(time);
   });
 
-  it('should reject with negative time', async () => {
-    await expect(delay(-100)).rejects.toThrow('Invalid time value');
+  it('should be called after the given time', async () => {
+    const mockFn = vi.fn();
+    vi.useFakeTimers();
+
+    delay(time, mockFn);
+
+    await vi.advanceTimersByTimeAsync(time);
+
+    expect(mockFn).toBeCalled();
   });
 
-  it('should reject with NaN time', async () => {
-    await expect(delay(NaN)).rejects.toThrow('Invalid time value');
+  it('should reject with invalid time', () => {
+    const errorMessage = 'Invalid time value';
+
+    expect(delay(-100)).rejects.toThrow(errorMessage);
+    expect(delay(NaN)).rejects.toThrow(errorMessage);
+    expect(delay(Infinity)).rejects.toThrow(errorMessage);
+    expect(delay(-Infinity)).rejects.toThrow(errorMessage);
   });
 });

--- a/packages/utils/src/common/delay/index.ts
+++ b/packages/utils/src/common/delay/index.ts
@@ -1,7 +1,12 @@
-export const delay = (time: number): Promise<void> => {
+export const delay = (time: number, callback?: () => void): Promise<void> => {
   return new Promise<void>((resolve, reject) => {
-    if (isNaN(time) || time < 0) reject(new Error('Invalid time value'));
+    if (!Number.isInteger(time) || time < 0) {
+      reject(new Error('Invalid time value'));
+    }
 
-    setTimeout(resolve, time);
+    setTimeout(() => {
+      if (callback) callback();
+      resolve();
+    }, time);
   });
 };


### PR DESCRIPTION
## Overview

delay함수를 개선합니다.
주어진 시간 이후에 특정 함수를 호출 할 수 있게 2번째 인자로 callback 함수를 받아올 수 있게 수정하였습니다.

또한 NaN의 경우와 더불어 Infinite, -Infinite, 소수 등과 같은 예외 케이스를 처리하기 위해 isNaN에서 [Number.isInterger](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger)로 변경하였습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)