### PR TITLE
feat(react): useIntersectionObserver 개선 및 InView, LazyImage 수정

### DIFF
--- a/.changeset/cyan-weeks-approve.md
+++ b/.changeset/cyan-weeks-approve.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+feat(react): useIntersectionObserver 개선 및 InView, LazyImage 수정 - @ssi02014

--- a/docs/docs/react/components/InView.mdx
+++ b/docs/docs/react/components/InView.mdx
@@ -6,7 +6,7 @@ import { InView } from '@modern-kit/react';
 
 `Viewport`에 노출될 때(`onIntersectStart`) 혹은 나갈 때(`onIntersectEnd`) 특정 action 함수를 호출 할 수 있는 컴포넌트입니다.
 
-`calledOnceVisible`을 활용해 컴포넌트가 `viewport에 노출 될 때 한번 onIntersectStart을 호출` 할 수 있습니다.
+`calledOnce`를 활용하면 `onIntersectStart`와 `onIntersectEnd`를 각각 한번씩 호출 할 수 있습니다.
 
 Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
@@ -26,7 +26,7 @@ interface IntersectionObserverInit {
 interface UseIntersectionObserverProps extends IntersectionObserverInit {
   onIntersectStart?: (entry: IntersectionObserverEntry) => void;
   onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
-  calledOnceVisible?: boolean;
+  calledOnce?: boolean;
 }
 
 type InViewProps = React.ComponentProps<'div'> & UseIntersectionObserverProps;
@@ -56,7 +56,7 @@ const Example = () => {
       <InView
         onIntersectStart={handleIntersectStart}
         onIntersectStart={handleIntersectEnd}
-        calledOnceVisible>
+        calledOnce>
         Box1
       </InView>
     </div>;
@@ -91,13 +91,13 @@ export const Example = () => {
         }}
         onIntersectStart={() => console.log('action onIntersectStart(1)')}
         onIntersectEnd={() => console.log('action onIntersectEnd(1)')}
-        calledOnceVisible
+        calledOnce
       >
         <div>
           <p>Box1</p>
           <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
           <p>onIntersectStart가 최초 1회만 호출됩니다.</p>
-          <p>calledOnceVisible: true</p>
+          <p>calledOnce: true</p>
         </div>
       </InView>
       <div style={{ height: '300px' }} />
@@ -113,7 +113,7 @@ export const Example = () => {
           <p>Box2</p>
           <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
           <p>onIntersectStart, onIntersectEnd 함수가 여러 번 호출됩니다.</p>
-          <p>calledOnceVisible: false</p>
+          <p>calledOnce: false</p>
         </div>
       </InView>
       <div style={{ width: '100%', height: '900px', textAlign: 'center' }} />

--- a/docs/docs/react/components/InView.mdx
+++ b/docs/docs/react/components/InView.mdx
@@ -2,7 +2,13 @@ import { InView } from '@modern-kit/react';
 
 # InView
 
-`Viewport`에 노출될 때 props로 넘겨주는 `action` 콜백 함수를 호출하는 컴포넌트입니다.
+`InView`는 **[useIntersectionObserver](https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useIntersectionObserver)**를 선언적으로 활용 할 수 있는 컴포넌트입니다.
+
+`Viewport`에 노출될 때(`onIntersectStart`) 혹은 나갈 때(`onIntersectEnd`) 특정 action 함수를 호출 할 수 있는 컴포넌트입니다.
+
+`calledOnceVisible`을 활용해 컴포넌트가 `viewport에 노출 될 때 한번 onIntersectStart을 호출` 할 수 있습니다.
+
+Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
 <br />
 
@@ -11,6 +17,18 @@ import { InView } from '@modern-kit/react';
 
 ## Interface
 ```ts title="typescript"
+interface IntersectionObserverInit {
+    root?: Element | Document | null;
+    rootMargin?: string;
+    threshold?: number | number[];
+}
+
+interface UseIntersectionObserverProps extends IntersectionObserverInit {
+  onIntersectStart?: (entry: IntersectionObserverEntry) => void;
+  onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
+  calledOnceVisible?: boolean;
+}
+
 type InViewProps = React.ComponentProps<'div'> & UseIntersectionObserverProps;
 
 const InView: React.ForwardRefExoticComponent<
@@ -24,46 +42,86 @@ const InView: React.ForwardRefExoticComponent<
 import { InView } from '@modern-kit/react';
 
 const Example = () => {
-  const onAction = () => {
+  const handleIntersectStart = () => {
+    /* action */
+  }
+
+  const handleIntersectEnd = () => {
     /* action */
   }
 
   return (
     <div>
       {/* ... */}
-      <InView action={onAction} calledOnce>Box1</InView>
-    </div>
+      <InView
+        onIntersectStart={handleIntersectStart}
+        onIntersectStart={handleIntersectEnd}
+        calledOnceVisible>
+        Box1
+      </InView>
+    </div>;
   );
 }; 
 ```
 
 ## Example
 
-<div style={{ maxWidth: "500px", height: "500px", overflow: "scroll", background: "#f1f3f5" }}>
-  <div style={{ width: "100%", height: "600px", textAlign: 'center', fontSize: '2rem' }}>스크롤 해주세요.</div>
-  <InView
-    style={{ width: "100%", height: "300px", background: "#c0392B", color: "white", textAlign: 'center', fontSize: "21px" }}
-    action={() => console.log("action callback(1)")}
-    calledOnce
-  >
+export const Example = () => {
+  const inViewStyle = {
+    width: '100%',
+    color: 'white',
+    textAlign: 'center',
+    fontSize: '21px',
+    padding: '0 20px',
+  }
+  return (
     <div>
-      <p>Box1</p>
-      <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
-      <p>action 콜백 함수가 최초 1회만 호출됩니다.</p>
-      <p>calledOnce: true</p>
+      <div
+        style={{
+          height: '500px',
+          textAlign: 'center',
+          fontSize: '2rem',
+        }}>
+        스크롤 해주세요.
+      </div>
+      <InView
+        style={{
+          ...inViewStyle,
+          background: '#c0392B',
+        }}
+        onIntersectStart={() => console.log('action onIntersectStart(1)')}
+        onIntersectEnd={() => console.log('action onIntersectEnd(1)')}
+        calledOnceVisible
+      >
+        <div>
+          <p>Box1</p>
+          <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
+          <p>onIntersectStart가 최초 1회만 호출됩니다.</p>
+          <p>calledOnceVisible: true</p>
+        </div>
+      </InView>
+      <div style={{ height: '300px' }} />
+      <InView
+        style={{
+          ...inViewStyle,
+          background: '#89a5ea',
+        }}
+        onIntersectStart={() => console.log('action onIntersectStart(2)')}
+        onIntersectEnd={() => console.log('action onIntersectEnd(2)')}
+      >
+        <div>
+          <p>Box2</p>
+          <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
+          <p>onIntersectStart, onIntersectEnd 함수가 여러 번 호출됩니다.</p>
+          <p>calledOnceVisible: false</p>
+        </div>
+      </InView>
+      <div style={{ width: '100%', height: '900px', textAlign: 'center' }} />
     </div>
-  </InView>
-  <div style={{ width: "100%", height: "100px" }} />
-  <InView
-    style={{ width: "100%", height: "300px", background: "#89a5ea", color: "white", textAlign: 'center', fontSize: "21px" }}
-    action={() => console.log("action callback(2)")}
-  >
-    <div>
-      <p>Box2</p>
-      <p>브라우저 개발자 도구의 콘솔을 확인해주세요.</p>
-      <p>action 콜백 함수가 여러 번 호출됩니다.</p>
-      <p>calledOnce: false</p>
-    </div>
-  </InView>
-  <div style={{ width: "100%", height: "600px", textAlign: 'center' }} />
-</div>
+  );
+};
+
+<Example />
+
+## Note
+- [Intersection Observer API](https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver)

--- a/docs/docs/react/components/LazyImage.mdx
+++ b/docs/docs/react/components/LazyImage.mdx
@@ -2,7 +2,7 @@ import { LazyImage } from '@modern-kit/react';
 
 # LazyImage
 
-`Viewport`에 노출될 때 할당된 이미지를 `Lazy Loading` 하는 이미지 컴포넌트입니다.
+**[useIntersectionObserver](https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useIntersectionObserver)**를 활용해 `Viewport`에 노출될 때 할당된 이미지를 `Lazy Loading` 하는 이미지 컴포넌트입니다.
 
 `width`, `height` 값을 입력해 이미지의 크기를 조절 할 수 있으며, 동시에 `Layout Shift`를 개선할 수 있습니다.
 
@@ -15,13 +15,21 @@ Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고
 
 ## Interface
 ```ts title="typescript"
+interface IntersectionObserverInit {
+  root?: Element | Document | null;
+  rootMargin?: string;
+  threshold?: number | number[];
+}
+
 interface LazyImageProps
   extends React.ComponentProps<'img'>,
     IntersectionObserverInit {
   src: string;
 }
 
-const LazyImage: React.ForwardRefExoticComponent<Omit<LazyImageProps, "ref"> & React.RefAttributes<HTMLImageElement>>
+const LazyImage: React.ForwardRefExoticComponent<
+  Omit<LazyImageProps, 'ref'> & React.RefAttributes<HTMLImageElement>
+>;
 ```
 
 ## Usage
@@ -92,44 +100,56 @@ const Example = () => {
 
 ## Example
 
-<div style={{ maxWidth: '500px', height: '500px', overflow:'scroll', background: '#f8f8f8' }}>
-  <div style={{ width: '100%', height: '500px',  textAlign: 'center', fontSize: '2rem' }}>
-    스크롤 해주세요.
-  </div>
-  <LazyImage
-    width={"100%"}
-    height={400}
-    src={
-      'https://github.com/Team-Grace/devgrace/assets/64779472/b5640bec-2abc-4205-afbf-ccfd9876a90b'
-    }
-    alt="img1"
-    onClick={() => console.log('img click1')}
-  />
+export const Example = () => {
+  return (
+    <div style={{ background: '#f8f8f8' }}>
+      <div
+        style={{
+          height: '500px',
+          textAlign: 'center',
+          fontSize: '2rem',
+        }}>
+        스크롤 해주세요.
+      </div>
+      <LazyImage
+        width={'100%'}
+        height={400}
+        src={
+          'https://github.com/Team-Grace/devgrace/assets/64779472/b5640bec-2abc-4205-afbf-ccfd9876a90b'
+        }
+        alt="img1"
+        onClick={() => console.log('img click1')}
+      />
 
-  <div style={{ width: '100%', height: '150px' }} />
+      <div style={{ width: '100%', height: '150px' }} />
 
-  <LazyImage
-    width={"100%"}
-    height={400}
-    src={
-      'https://github.com/Team-Grace/devgrace/assets/64779472/207743a7-b29f-4826-bc08-8df0d67e568b'
-    }
-    alt="img2"
-    onClick={() => console.log('img click2')}
-  />
+      <LazyImage
+        width={'100%'}
+        height={400}
+        src={
+          'https://github.com/Team-Grace/devgrace/assets/64779472/207743a7-b29f-4826-bc08-8df0d67e568b'
+        }
+        alt="img2"
+        onClick={() => console.log('img click2')}
+      />
 
-  <div style={{ width: '100%', height: '150px' }} />
+      <div style={{ width: '100%', height: '150px' }} />
 
-  <LazyImage
-    width={"100%"}
-    height={400}
-    src={
-      'https://github.com/Team-Grace/devgrace/assets/64779472/d1957ec8-fe87-406e-bfda-fb4ee505b152'
-    }
-    alt="img3"
-    onClick={() => console.log('img click3')}
-  />
-</div>
+      <LazyImage
+        width={'100%'}
+        height={400}
+        src={
+          'https://github.com/Team-Grace/devgrace/assets/64779472/d1957ec8-fe87-406e-bfda-fb4ee505b152'
+        }
+        alt="img3"
+        onClick={() => console.log('img click3')}
+      />
+    </div>
+  );
+};
+
+<Example />
+
 
 ## Note
 - [Intersection Observer API](https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver)

--- a/docs/docs/react/hooks/useIntersectionObserver.mdx
+++ b/docs/docs/react/hooks/useIntersectionObserver.mdx
@@ -1,6 +1,10 @@
+import { useIntersectionObserver } from '@modern-kit/react';
+
 # useIntersectionObserver
 
-`ref`를 할당한 타겟 엘리먼트가 `Viewport`에 노출되는 시점에 `action` 콜백 함수를 호출시키는 커스텀 훅입니다.
+`ref`를 할당한 타겟 엘리먼트가 `Viewport`에 노출될 때(`onIntersectStart`) 혹은 나갈 때(`onIntersectEnd`) 특정 action 함수를 호출 할 수 있는 컴포넌트입니다.
+
+`calledOnceVisible`을 활용해 타겟 엘리먼트가 `viewport에 노출 될 때 한번 onIntersectStart을 호출` 할 수 있습니다.
 
 Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
@@ -11,18 +15,28 @@ Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고
 
 ## Interface
 ```ts title="typescript"
+interface IntersectionObserverInit {
+    root?: Element | Document | null;
+    rootMargin?: string;
+    threshold?: number | number[];
+}
+
 interface UseIntersectionObserverProps extends IntersectionObserverInit {
-  action: (entry: IntersectionObserverEntry) => void;
-  calledOnce?: boolean;
+  onIntersectStart?: (entry: IntersectionObserverEntry) => void;
+  onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
+  calledOnceVisible?: boolean;
 }
 
 const useIntersectionObserver: <T extends HTMLElement>({
-  action,
-  calledOnce,
-  root,
-  threshold,
-  rootMargin,
-}: UseIntersectionObserverProps) => (node: T) => void;
+  onIntersectStart,
+  onIntersectEnd,
+  calledOnceVisible, // default: false
+  root, // default: null
+  threshold, // default: 0
+  rootMargin, // default: '0px 0px 0px 0px'
+}: UseIntersectionObserverProps) => {
+  ref: (node: T) => void;
+};
 ```
 
 ## Usage
@@ -30,22 +44,63 @@ const useIntersectionObserver: <T extends HTMLElement>({
 import { useIntersectionObserver } from '@modern-kit/react';
 
 const Example = () => {
-  const divRef = useIntersectionObserver<HTMLDivElement>({
-    action: () => { /* action */},
+  const { ref: targetRef } = useIntersectionObserver({
+    onIntersectStart: (entry) => {
+      console.log("onIntersectStart: ", entry);
+    },
+    onIntersectEnd: (entry) => {
+      console.log("onIntersectEnd: ", entry);
+    },
+    calledOnceVisible: false
   });
-  const imgRef = useIntersectionObserver<HTMLImageElement>({
-    action: (entry) => { /* 필요하다면 IntersectionObserverEntry 를 사용할 수 있습니다. */},
-  });
+  
+  const boxStyle = {
+    height: "800px", 
+    backgroundColor: "teal"
+  }
 
   return (
     <div>
-      {/* ... */}
-      <div ref={divRef}>Box</div>
-      <img ref={imgRef} src="url" alt="img" />
+      <div style={boxStyle} />
+      <div ref={targetRef} style={{ color: "white", fontSize: "24px", backgroundColor: "blue" }}>
+        타겟 요소<br />
+        개발자 도구 콘솔을 확인해주세요.
+      </div>
+      <div style={boxStyle} />
     </div>
   );
 };
 ```
+
+## Exmaple
+
+export const Example = () => {
+  const { ref: targetRef } = useIntersectionObserver({
+    onIntersectStart: (entry) => {
+      console.log("onIntersectStart: ", entry);
+    },
+    onIntersectEnd: (entry) => {
+      console.log("onIntersectEnd: ", entry);
+    },
+    calledOnceVisible: false
+  });
+  const boxStyle = {
+    height: "800px", 
+    backgroundColor: "teal"
+  }
+  return (
+    <div>
+      <div style={boxStyle} />
+      <div ref={targetRef} style={{ color: "white", fontSize: "24px", backgroundColor: "blue" }}>
+        타겟 요소<br />
+        개발자 도구 콘솔을 확인해주세요.
+      </div>
+      <div style={boxStyle} />
+    </div>
+  );
+};
+
+<Example />
 
 ## Note
 - [Intersection Observer API](https://developer.mozilla.org/ko/docs/Web/API/IntersectionObserver)

--- a/docs/docs/react/hooks/useIntersectionObserver.mdx
+++ b/docs/docs/react/hooks/useIntersectionObserver.mdx
@@ -4,7 +4,7 @@ import { useIntersectionObserver } from '@modern-kit/react';
 
 `ref`를 할당한 타겟 엘리먼트가 `Viewport`에 노출될 때(`onIntersectStart`) 혹은 나갈 때(`onIntersectEnd`) 특정 action 함수를 호출 할 수 있는 컴포넌트입니다.
 
-`calledOnceVisible`을 활용해 타겟 엘리먼트가 `viewport에 노출 될 때 한번 onIntersectStart을 호출` 할 수 있습니다.
+`calledOnce`옵션을 `true`로 설정하면 `onIntersectStart`와 `onIntersectEnd`를 각각 한번씩 호출 할 수 있습니다.
 
 Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
@@ -24,13 +24,13 @@ interface IntersectionObserverInit {
 interface UseIntersectionObserverProps extends IntersectionObserverInit {
   onIntersectStart?: (entry: IntersectionObserverEntry) => void;
   onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
-  calledOnceVisible?: boolean;
+  calledOnce?: boolean;
 }
 
 const useIntersectionObserver: <T extends HTMLElement>({
   onIntersectStart,
   onIntersectEnd,
-  calledOnceVisible, // default: false
+  calledOnce, // default: false
   root, // default: null
   threshold, // default: 0
   rootMargin, // default: '0px 0px 0px 0px'
@@ -51,7 +51,7 @@ const Example = () => {
     onIntersectEnd: (entry) => {
       console.log("onIntersectEnd: ", entry);
     },
-    calledOnceVisible: false
+    calledOnce: false
   });
   
   const boxStyle = {
@@ -82,7 +82,7 @@ export const Example = () => {
     onIntersectEnd: (entry) => {
       console.log("onIntersectEnd: ", entry);
     },
-    calledOnceVisible: false
+    calledOnce: false
   });
   const boxStyle = {
     height: "800px", 

--- a/packages/react/src/components/InView/InView.spec.tsx
+++ b/packages/react/src/components/InView/InView.spec.tsx
@@ -18,19 +18,19 @@ afterEach(() => {
 interface TestComponentProps {
   onIntersectStart: () => void;
   onIntersectEnd: () => void;
-  calledOnceVisible?: boolean;
+  calledOnce?: boolean;
 }
 
 const TestComponent = ({
   onIntersectStart,
   onIntersectEnd,
-  calledOnceVisible,
+  calledOnce,
 }: TestComponentProps) => {
   return (
     <InView
       onIntersectStart={onIntersectStart}
       onIntersectEnd={onIntersectEnd}
-      calledOnceVisible={calledOnceVisible}>
+      calledOnce={calledOnce}>
       box
     </InView>
   );
@@ -65,22 +65,23 @@ describe('InView Component', () => {
       <TestComponent
         onIntersectStart={intersectStartMock}
         onIntersectEnd={intersectEndMock}
-        calledOnceVisible={true}
+        calledOnce={true}
       />
     );
 
     const box = screen.getByText('box');
 
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
-
     expect(intersectStartMock).toBeCalledTimes(1);
 
     await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    expect(intersectEndMock).toBeCalledTimes(1);
+
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
     await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
     expect(intersectStartMock).toBeCalledTimes(1);
-    expect(intersectEndMock).toBeCalledTimes(0);
+    expect(intersectEndMock).toBeCalledTimes(1);
   });
 });

--- a/packages/react/src/components/InView/InView.spec.tsx
+++ b/packages/react/src/components/InView/InView.spec.tsx
@@ -15,80 +15,72 @@ afterEach(() => {
   mockIntersectionObserverCleanup();
 });
 
+interface TestComponentProps {
+  onIntersectStart: () => void;
+  onIntersectEnd: () => void;
+  calledOnceVisible?: boolean;
+}
+
 const TestComponent = ({
-  action1,
-  action2,
-}: {
-  action1: () => void;
-  action2: () => void;
-}) => {
+  onIntersectStart,
+  onIntersectEnd,
+  calledOnceVisible,
+}: TestComponentProps) => {
   return (
-    <div>
-      <InView action={action1} calledOnce>
-        box1
-      </InView>
-      <InView action={action2}>box2</InView>
-    </div>
+    <InView
+      onIntersectStart={onIntersectStart}
+      onIntersectEnd={onIntersectEnd}
+      calledOnceVisible={calledOnceVisible}>
+      box
+    </InView>
   );
 };
 
 describe('InView Component', () => {
+  const intersectStartMock = vi.fn();
+  const intersectEndMock = vi.fn();
+
   it('should call the action function when the InView component is exposed to the viewport', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
+    renderSetup(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+      />
+    );
 
-    const box1 = screen.getByText('box1');
-    const box2 = screen.getByText('box2');
+    const box = screen.getByText('box');
 
-    expect(mockFn1).toBeCalledTimes(0);
-    expect(mockFn2).toBeCalledTimes(0);
+    expect(intersectStartMock).toBeCalledTimes(0);
+    expect(intersectEndMock).toBeCalledTimes(0);
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    expect(mockFn1).toBeCalledTimes(1);
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    expect(intersectStartMock).toBeCalledTimes(1);
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(1);
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    expect(intersectEndMock).toBeCalledTimes(1);
   });
 
   it('should call the action callback function once if the calledOnce prop is true', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
+    renderSetup(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+        calledOnceVisible={true}
+      />
+    );
 
-    const box1 = screen.getByText('box1');
+    const box = screen.getByText('box');
 
-    expect(mockFn2).toBeCalledTimes(0);
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    expect(mockFn1).toBeCalledTimes(1);
+    expect(intersectStartMock).toBeCalledTimes(1);
 
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
-    expect(mockFn1).toBeCalledTimes(1);
-  });
-
-  it('should call the action callback function every time it is exposed to the viewport if the calledOnce prop is false', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
-
-    const box2 = screen.getByText('box2');
-
-    expect(mockFn2).toBeCalledTimes(0);
-
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(1);
-
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box2 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(2);
-
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box2 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(3);
+    expect(intersectStartMock).toBeCalledTimes(1);
+    expect(intersectEndMock).toBeCalledTimes(0);
   });
 });

--- a/packages/react/src/components/InView/index.tsx
+++ b/packages/react/src/components/InView/index.tsx
@@ -14,7 +14,7 @@ export const InView = forwardRef<
   const {
     onIntersectStart,
     onIntersectEnd,
-    calledOnceVisible,
+    calledOnce,
     threshold,
     root,
     rootMargin,
@@ -25,7 +25,7 @@ export const InView = forwardRef<
     useIntersectionObserver<HTMLDivElement>({
       onIntersectStart,
       onIntersectEnd,
-      calledOnceVisible,
+      calledOnce,
       threshold,
       root,
       rootMargin,

--- a/packages/react/src/components/InView/index.tsx
+++ b/packages/react/src/components/InView/index.tsx
@@ -11,16 +11,25 @@ export const InView = forwardRef<
   HTMLDivElement,
   PropsWithChildren<InViewProps>
 >((props, ref) => {
-  const { action, calledOnce, threshold, root, rootMargin, ...restProps } =
-    props;
-
-  const intersectionObserverRef = useIntersectionObserver<HTMLDivElement>({
-    action,
-    calledOnce,
+  const {
+    onIntersectStart,
+    onIntersectEnd,
+    calledOnceVisible,
     threshold,
     root,
     rootMargin,
-  });
+    ...restProps
+  } = props;
+
+  const { ref: intersectionObserverRef } =
+    useIntersectionObserver<HTMLDivElement>({
+      onIntersectStart,
+      onIntersectEnd,
+      calledOnceVisible,
+      threshold,
+      root,
+      rootMargin,
+    });
 
   return (
     <div ref={useMergeRefs(ref, intersectionObserverRef)} {...restProps}>

--- a/packages/react/src/components/LazyImage/index.tsx
+++ b/packages/react/src/components/LazyImage/index.tsx
@@ -13,12 +13,12 @@ export const LazyImage = forwardRef<HTMLImageElement, LazyImageProps>(
     { src, style, threshold, root, rootMargin, ...restProps }: LazyImageProps,
     ref
   ) => {
-    const imgRef = useIntersectionObserver<HTMLImageElement>({
-      action: (entry) => {
+    const { ref: imgRef } = useIntersectionObserver<HTMLImageElement>({
+      onIntersectStart: (entry) => {
         const targetImgElement = entry.target as HTMLImageElement;
         targetImgElement.src = src;
       },
-      calledOnce: true,
+      calledOnceVisible: true,
       threshold,
       root,
       rootMargin,

--- a/packages/react/src/components/LazyImage/index.tsx
+++ b/packages/react/src/components/LazyImage/index.tsx
@@ -18,7 +18,7 @@ export const LazyImage = forwardRef<HTMLImageElement, LazyImageProps>(
         const targetImgElement = entry.target as HTMLImageElement;
         targetImgElement.src = src;
       },
-      calledOnceVisible: true,
+      calledOnce: true,
       threshold,
       root,
       rootMargin,

--- a/packages/react/src/hooks/useIntersectionObserver/index.ts
+++ b/packages/react/src/hooks/useIntersectionObserver/index.ts
@@ -17,6 +17,7 @@ export const useIntersectionObserver = <T extends HTMLElement>({
   threshold = 0,
   rootMargin = '0px 0px 0px 0px',
 }: UseIntersectionObserverProps) => {
+  const isVisible = useRef(false);
   const intersectionObserverRef = useRef<Nullable<IntersectionObserver>>(null);
 
   const intersectionObserverCallback = usePreservedCallback(
@@ -26,12 +27,15 @@ export const useIntersectionObserver = <T extends HTMLElement>({
       if (entry.isIntersecting) {
         const targetElement = entry.target as T;
 
+        isVisible.current = true;
         onIntersectStart(entry);
 
         if (calledOnceVisible) {
           observer.unobserve(targetElement);
         }
-      } else {
+      } else if (isVisible.current) {
+        // 최초 mount 시에 호출을 방지하고, 타겟 요소가 viewport에서 나갈 때만 호출
+        isVisible.current = false;
         onIntersectEnd(entry);
       }
     }

--- a/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
+++ b/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
@@ -18,18 +18,18 @@ afterEach(() => {
 interface TestComponentProps {
   onIntersectStart: () => void;
   onIntersectEnd: () => void;
-  calledOnceVisible?: boolean;
+  calledOnce?: boolean;
 }
 
 const TestComponent = ({
   onIntersectStart,
   onIntersectEnd,
-  calledOnceVisible,
+  calledOnce,
 }: TestComponentProps) => {
   const { ref: boxRef } = useIntersectionObserver<HTMLDivElement>({
     onIntersectStart,
     onIntersectEnd,
-    calledOnceVisible,
+    calledOnce,
   });
 
   return <div ref={boxRef}>box</div>;
@@ -59,12 +59,12 @@ describe('useIntersectionObserver', () => {
     expect(intersectEndMock).toBeCalledTimes(1);
   });
 
-  it('should call the action callback function only once when the calledOnceVisible option is true', async () => {
+  it('should call the action callback function only once when the calledOnce option is true', async () => {
     renderSetup(
       <TestComponent
         onIntersectStart={intersectStartMock}
         onIntersectEnd={intersectEndMock}
-        calledOnceVisible={true}
+        calledOnce={true}
       />
     );
 
@@ -74,11 +74,13 @@ describe('useIntersectionObserver', () => {
     expect(intersectStartMock).toBeCalledTimes(1);
 
     await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    expect(intersectEndMock).toBeCalledTimes(1);
+
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
     await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
     expect(intersectStartMock).toBeCalledTimes(1);
-    expect(intersectEndMock).toBeCalledTimes(0);
+    expect(intersectEndMock).toBeCalledTimes(1);
   });
 });

--- a/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
+++ b/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
@@ -15,86 +15,70 @@ afterEach(() => {
   mockIntersectionObserverCleanup();
 });
 
+interface TestComponentProps {
+  onIntersectStart: () => void;
+  onIntersectEnd: () => void;
+  calledOnceVisible?: boolean;
+}
+
 const TestComponent = ({
-  action1,
-  action2,
-}: {
-  action1: () => void;
-  action2: () => void;
-}) => {
-  const boxRef1 = useIntersectionObserver<HTMLDivElement>({
-    action: action1,
-    calledOnce: true,
-  });
-  const boxRef2 = useIntersectionObserver<HTMLDivElement>({
-    action: action2,
+  onIntersectStart,
+  onIntersectEnd,
+  calledOnceVisible,
+}: TestComponentProps) => {
+  const { ref: boxRef } = useIntersectionObserver<HTMLDivElement>({
+    onIntersectStart,
+    onIntersectEnd,
+    calledOnceVisible,
   });
 
-  return (
-    <div>
-      <div ref={boxRef1}>box1</div>
-      <div ref={boxRef2}>box2</div>
-    </div>
-  );
+  return <div ref={boxRef}>box</div>;
 };
 
 describe('useIntersectionObserver', () => {
+  const intersectStartMock = vi.fn();
+  const intersectEndMock = vi.fn();
+
   it('should call the action callback function when the target element assigned to the returned "ref" is exposed to the Viewport', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
+    renderSetup(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+      />
+    );
 
-    const box1 = screen.getByText('box1');
-    const box2 = screen.getByText('box2');
+    const box = screen.getByText('box');
 
-    expect(mockFn1).toBeCalledTimes(0);
-    expect(mockFn2).toBeCalledTimes(0);
+    expect(intersectStartMock).toBeCalledTimes(0);
+    expect(intersectEndMock).toBeCalledTimes(0);
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    expect(mockFn1).toBeCalledTimes(1);
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    expect(intersectStartMock).toBeCalledTimes(1);
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(1);
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    expect(intersectEndMock).toBeCalledTimes(1);
   });
 
-  it('should call the action callback function only once when the calledOnce option is true', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
+  it('should call the action callback function only once when the calledOnceVisible option is true', async () => {
+    renderSetup(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+        calledOnceVisible={true}
+      />
+    );
 
-    const box1 = screen.getByText('box1');
+    const box = screen.getByText('box');
 
-    expect(mockFn2).toBeCalledTimes(0);
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    expect(intersectStartMock).toBeCalledTimes(1);
 
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    expect(mockFn1).toBeCalledTimes(1);
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box1 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box1 }));
-
-    expect(mockFn1).toBeCalledTimes(1);
-  });
-
-  it('should call the action callback function every time the target element is exposed to the Viewport when the calledOnce option is false', async () => {
-    const mockFn1 = vi.fn();
-    const mockFn2 = vi.fn();
-    renderSetup(<TestComponent action1={mockFn1} action2={mockFn2} />);
-
-    const box2 = screen.getByText('box2');
-
-    expect(mockFn2).toBeCalledTimes(0);
-
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(1);
-
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box2 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(2);
-
-    await waitFor(() => mockIntersecting({ type: 'hide', element: box2 }));
-    await waitFor(() => mockIntersecting({ type: 'view', element: box2 }));
-    expect(mockFn2).toBeCalledTimes(3);
+    expect(intersectStartMock).toBeCalledTimes(1);
+    expect(intersectEndMock).toBeCalledTimes(0);
   });
 });


### PR DESCRIPTION
## Overview

useIntersectionObserver를 개선합니다.
기존에는 타겟 요소가 viewport에 노출 될 때만 action 콜백을 호출했지만, `노출 될 때(onIntersectStart)`와 `나갈 때(onIntersectStart)` 모두 대응 할 수 있게 수정하였습니다.

useIntersectionObserver가 수정됨에 따라 InView, LazyImage 컴포넌트도 수정하였습니다.

<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)