### PR TITLE
feat(utils): invert, identity 유틸 함수 추가

### DIFF
--- a/.changeset/fresh-worms-melt.md
+++ b/.changeset/fresh-worms-melt.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): invert, identity 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/common/identity.md
+++ b/docs/docs/utils/common/identity.md
@@ -1,0 +1,22 @@
+# identity
+
+인자로 받은 값을 그대로 반환하는 함수입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/common/identity/index.ts)
+
+## Interface
+```ts title="typescript"
+const identity: <T>(value: T) => T;
+```
+
+## Usage
+```ts title="typescript"
+import { identity } from '@modern-kit/utils';
+
+identity(1); // 1
+identity('foo'); // 'foo'
+identity([]); // []
+```

--- a/docs/docs/utils/object/invert.md
+++ b/docs/docs/utils/object/invert.md
@@ -1,0 +1,42 @@
+# invert
+
+객체의 `key`와 `value`를 뒤집는 함수입니다.
+
+필요 시 2번째 인자로 함수(`keyTransformer`)를 넘겨 key를 직접 핸들링 할 수 있습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/object/invert/index.ts)
+
+## Interface
+```ts title="typescript"
+const invert: (
+  obj: Record<PropertyKey, any>,
+  keyTransformer?: (value: any) => PropertyKey
+) => Record<PropertyKey, any>;
+```
+
+## Usage
+### Default
+```ts title="typescript"
+import { invert } from '@modern-kit/utils';
+
+const obj1 = { a: 1, b: 2, c: 3 };
+invert(obj1); // { 1: 'a', 2: 'b', 3: 'c' };
+
+const obj2 = { a: 1, b: [1, 2, 3] };
+invert(obj2, (value) => {
+  return JSON.stringify(value);
+}); // { '1': 'a', '[1,2,3]': 'b' }
+```
+
+### KeyTransformer
+```ts title="typescript"
+import { invert } from '@modern-kit/utils';
+
+const obj2 = { a: 1, b: [1, 2, 3] };
+invert(obj2, (value) => {
+  return JSON.stringify(value);
+}); // { '1': 'a', '[1,2,3]': 'b' }
+```

--- a/docs/docs/utils/object/invert.md
+++ b/docs/docs/utils/object/invert.md
@@ -22,21 +22,18 @@ const invert: (
 ```ts title="typescript"
 import { invert } from '@modern-kit/utils';
 
-const obj1 = { a: 1, b: 2, c: 3 };
-invert(obj1); // { 1: 'a', 2: 'b', 3: 'c' };
+const obj = { a: 1, b: 2, c: 3 };
 
-const obj2 = { a: 1, b: [1, 2, 3] };
-invert(obj2, (value) => {
-  return JSON.stringify(value);
-}); // { '1': 'a', '[1,2,3]': 'b' }
+invert(obj); // { 1: 'a', 2: 'b', 3: 'c' };
 ```
 
 ### KeyTransformer
 ```ts title="typescript"
 import { invert } from '@modern-kit/utils';
 
-const obj2 = { a: 1, b: [1, 2, 3] };
-invert(obj2, (value) => {
+const obj = { a: [1, 2, 3], b: [4, 5, 6] };
+
+invert(obj, (value) => {
   return JSON.stringify(value);
-}); // { '1': 'a', '[1,2,3]': 'b' }
+}); // { '[1,2,3]': 'a', '[4,5,6]': 'b' }
 ```

--- a/packages/utils/src/common/identity/identity.spec.ts
+++ b/packages/utils/src/common/identity/identity.spec.ts
@@ -1,0 +1,71 @@
+import { identity } from '.';
+
+describe('identity', () => {
+  it('should return the same string value', () => {
+    const value = 'test';
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<string>();
+  });
+
+  it('should return the same number value', () => {
+    const value = 42;
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<number>();
+  });
+
+  it('should return the same boolean value', () => {
+    const value = true;
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<boolean>();
+  });
+
+  it('should return the same object reference', () => {
+    const value = { key: 'value' };
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expect(result).toEqual(value); // 참조가 동일한지 확인
+    expectTypeOf(result).toEqualTypeOf<{
+      key: string;
+    }>();
+  });
+
+  it('should return the same array reference', () => {
+    const value = [1, 2, 3];
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expect(result).toEqual(value); // 참조가 동일한지 확인
+    expectTypeOf(result).toEqualTypeOf<number[]>();
+  });
+
+  it('should return the same function reference', () => {
+    const value = () => 'function';
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<() => string>();
+  });
+
+  it('should return the same value for null', () => {
+    const value = null;
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<null>();
+  });
+
+  it('should return the same value for undefined', () => {
+    const value = undefined;
+    const result = identity(value);
+
+    expect(result).toBe(value);
+    expectTypeOf(result).toEqualTypeOf<undefined>();
+  });
+});

--- a/packages/utils/src/common/identity/index.ts
+++ b/packages/utils/src/common/identity/index.ts
@@ -1,0 +1,1 @@
+export const identity = <T>(value: T) => value;

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -7,6 +7,7 @@ export * from './getUniqId';
 export * from './getUniqTime';
 export * from './getViewportSize';
 export * from './hexToRgba';
+export * from './identity';
 export * from './noop';
 export * from './wrapInArray';
 export * from './parseJson';

--- a/packages/utils/src/object/index.ts
+++ b/packages/utils/src/object/index.ts
@@ -1,4 +1,5 @@
 export * from './deleteFalsyProperties';
+export * from './invert';
 export * from './mergeProperties';
 export * from './objectEntries';
 export * from './objectKeys';

--- a/packages/utils/src/object/invert/index.ts
+++ b/packages/utils/src/object/invert/index.ts
@@ -1,0 +1,15 @@
+import { identity } from '../../common';
+
+export const invert = (
+  obj: Record<PropertyKey, any>,
+  keyTransformer: (value: any) => PropertyKey = identity
+) => {
+  const invertedObj: Record<PropertyKey, any> = {};
+
+  Object.keys(obj).forEach((key) => {
+    const value = obj[key];
+    invertedObj[keyTransformer(value)] = key;
+  });
+
+  return invertedObj;
+};

--- a/packages/utils/src/object/invert/invert.spec.ts
+++ b/packages/utils/src/object/invert/invert.spec.ts
@@ -1,0 +1,41 @@
+import { invert } from '.';
+
+describe('invert', () => {
+  it('should invert the keys and values of an object', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = invert(obj);
+
+    expect(result).toEqual({ 1: 'a', 2: 'b', 3: 'c' });
+  });
+
+  it('should use the keyTransformer if provided', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const keyTransformer = (value: number) => `key_${value}`;
+    const result = invert(obj, keyTransformer);
+
+    expect(result).toEqual({ key_1: 'a', key_2: 'b', key_3: 'c' });
+  });
+
+  it('should handle an empty object', () => {
+    const obj = {};
+    const result = invert(obj);
+
+    expect(result).toEqual({});
+  });
+
+  it('should handle objects with duplicate values', () => {
+    const obj = { a: 1, b: 1, c: 2 };
+    const result = invert(obj);
+
+    expect(result).toEqual({ 1: 'b', 2: 'c' });
+  });
+
+  it('should skip properties not directly on the object', () => {
+    const obj = Object.create({ inherited: 'inherited' });
+    obj.a = 1;
+    obj.b = 2;
+    const result = invert(obj);
+
+    expect(result).toEqual({ 1: 'a', 2: 'b' });
+  });
+});


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/193

invert는 객체의 key와 value를 뒤집는 함수입니다.

```ts
const obj = { a: 1, b: 2, c: 3 };
const newObj = invert(obj); // { 1: 'a', 2: 'b', 3: 'c' };
```

만약 키가 동일한게 있다면 뒤에 있는 요소로 덮어씁니다.

```ts
const obj = { a: 1, b: 2, c: 1 };
const newObj = invert(obj); // { 1: 'c', 2: 'b' };
```

2번째 인자로 함수를 넘겨 (`keyTransformer`) 직접 key 핸들링 작업을 할 수 있습니다

```ts
const obj = { a: 1, b: 2, c: 3 };
const newObj = invert(obj, (value) => {
  return `test${value}`
}); // { test1: 'a', test2: 'b', test3: 'c' };
```
```ts
const obj = { a: 1, b: [1, 2, 3] };
const newObj = invert(obj, (value) => {
  return JSON.stringify(value);
}); // { '1': 'a', '[1,2,3]': 'b' }
```

<br />

identity함수는 인자로 받은 함수를 그대로 반환하는 유틸 함수입니다.

```ts
identity("test"); // "test"
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)