### PR TITLE
feat(utils): partition 유틸 함수 추가

### DIFF
--- a/.changeset/wet-actors-drop.md
+++ b/.changeset/wet-actors-drop.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): partition 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/array/partition.md
+++ b/docs/docs/utils/array/partition.md
@@ -1,0 +1,52 @@
+# partition
+
+첫 번째 인자의 `배열`을 기준으로 2번째 인자인 `predicate` 함수가 `true를 반환하는 요소들의 모음`과 `false를 반환하는 요소들의 모음` 두 그룹으로 나눈 배열을 반환하는 함수입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/partition/index.ts)
+
+## Interface
+```ts title="typescript"
+const partition: <T>(
+  arr: readonly T[] | T[],
+  predicate: (item: T) => boolean
+) => [truthyArray: T[], falsyArray: T[]];
+```
+
+## Usage
+```ts title="typescript"
+import { partition } from '@modern-kit/utils';
+
+const numberList = [1, 2, 3, 4, 5];
+const [evens, odds] = partition(numberList, (num) => num % 2 === 0);
+
+/*
+  evens: [2, 4]
+  odds: [1, 3, 5]
+*/
+```
+
+```ts title="typescript"
+import { partition } from '@modern-kit/utils';
+
+const users = [
+  { user: 'barney', age: 36, active: false },
+  { user: 'fred', age: 40, active: true },
+  { user: 'pebbles', age: 1,  active: false }
+];
+
+const [activeUsers, inActiveUsers] = partition(
+  users,
+  (item) => item.active
+);
+
+/*
+  activeUsers: [{ user: 'fred', age: 40, active: true }]
+  inActiveUsers: [
+    { user: 'barney', age: 36, active: false },
+    { user: 'pebbles', age: 1, active: false },
+  ]
+*/
+```

--- a/packages/utils/src/array/index.ts
+++ b/packages/utils/src/array/index.ts
@@ -2,3 +2,4 @@ export * from './chunk';
 export * from './contain';
 export * from './countOccurrencesInArray';
 export * from './excludeElements';
+export * from './partition';

--- a/packages/utils/src/array/partition/index.ts
+++ b/packages/utils/src/array/partition/index.ts
@@ -1,0 +1,17 @@
+export const partition = <T>(
+  arr: T[] | ReadonlyArray<T>,
+  predicate: (item: T) => boolean
+): [truthyArray: T[], falsyArray: T[]] => {
+  const truthyArray: T[] = [];
+  const falsyArray: T[] = [];
+
+  arr.forEach((item) => {
+    if (predicate(item)) {
+      truthyArray.push(item);
+    } else {
+      falsyArray.push(item);
+    }
+  });
+
+  return [truthyArray, falsyArray];
+};

--- a/packages/utils/src/array/partition/partition.spec.ts
+++ b/packages/utils/src/array/partition/partition.spec.ts
@@ -1,0 +1,46 @@
+import { partition } from '.';
+
+describe('partition', () => {
+  it('should partition an array of numbers based on a predicate', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const [evens, odds] = partition(arr, (num) => num % 2 === 0);
+
+    expect(evens).toEqual([2, 4]);
+    expect(odds).toEqual([1, 3, 5]);
+  });
+
+  it('should partition an array of strings based on a predicate', () => {
+    const arr = ['apple', 'banana', 'cherry', 'date'];
+    const [longer, shorter] = partition(arr, (str) => str.length > 5);
+
+    expect(longer).toEqual(['banana', 'cherry']);
+    expect(shorter).toEqual(['apple', 'date']);
+  });
+
+  it('should handle an empty array', () => {
+    const arr: number[] = [];
+    const [evens, odds] = partition(arr, (num) => num % 2 === 0);
+
+    expect(evens).toEqual([]);
+    expect(odds).toEqual([]);
+  });
+
+  it('should partition an array of objects based on a predicate', () => {
+    const users = [
+      { user: 'barney', age: 36, active: false },
+      { user: 'fred', age: 40, active: true },
+      { user: 'pebbles', age: 1, active: false },
+    ];
+
+    const [activeUsers, inActiveUsers] = partition(
+      users,
+      (item) => item.active
+    );
+
+    expect(activeUsers).toEqual([{ user: 'fred', age: 40, active: true }]);
+    expect(inActiveUsers).toEqual([
+      { user: 'barney', age: 36, active: false },
+      { user: 'pebbles', age: 1, active: false },
+    ]);
+  });
+});


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/215

첫 번째 인자의 배열을 기준으로 2번째 인자인 `predicate` 함수가 `true를 반환하는 요소들의 모음`과 `false를 반환하는 요소`들의 모음 두 그룹으로 나눈 배열을 반환하는 함수입니다.

<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)