### PR TITLE
fix: invert 명확한 타입 추론을 위한 타입 개선

### DIFF
--- a/docs/docs/utils/object/invert.md
+++ b/docs/docs/utils/object/invert.md
@@ -18,7 +18,7 @@ const invert: <
 >(
   obj: Record<K, V>,
   keyTransformer?: (value: V) => TK
-) => Record<K, V>;
+) => Record<TK, Exclude<K, symbol>>;
 ```
 
 ## Usage

--- a/docs/docs/utils/object/invert.md
+++ b/docs/docs/utils/object/invert.md
@@ -11,10 +11,14 @@
 
 ## Interface
 ```ts title="typescript"
-const invert: (
-  obj: Record<PropertyKey, any>,
-  keyTransformer?: (value: any) => PropertyKey
-) => Record<PropertyKey, any>;
+const invert: <
+  K extends PropertyKey,
+  V,
+  TK extends PropertyKey = V extends PropertyKey ? V : PropertyKey
+>(
+  obj: Record<K, V>,
+  keyTransformer?: (value: V) => TK
+) => Record<K, V>;
 ```
 
 ## Usage
@@ -24,7 +28,9 @@ import { invert } from '@modern-kit/utils';
 
 const obj = { a: 1, b: 2, c: 3 };
 
-invert(obj); // { 1: 'a', 2: 'b', 3: 'c' };
+invert(obj);
+// value: { 1: 'a', 2: 'b', 3: 'c' };
+// type: Record<number, "a" | "b" | "c">
 ```
 
 ### KeyTransformer
@@ -35,5 +41,21 @@ const obj = { a: [1, 2, 3], b: [4, 5, 6] };
 
 invert(obj, (value) => {
   return JSON.stringify(value);
-}); // { '[1,2,3]': 'a', '[4,5,6]': 'b' }
+}); 
+// value: { '[1,2,3]': 'a', '[4,5,6]': 'b' }
+// type: Record<string, "a" | "b">
+```
+
+### const assertion
+```ts title="typescript"
+import { invert } from '@modern-kit/utils';
+
+const obj = {
+  a: { name: 'foo' },
+  b: { name: 'bar' },
+} as const;
+
+invert(obj, (value) => value.name);
+// value: { foo: 'a', bar: 'b' }
+// type: Record<"foo" | "bar", "a" | "b">
 ```

--- a/packages/utils/src/object/invert/index.ts
+++ b/packages/utils/src/object/invert/index.ts
@@ -1,15 +1,27 @@
-import { identity } from '../../common';
+import { hasProperty } from '../../validator';
 
-export const invert = (
-  obj: Record<PropertyKey, any>,
-  keyTransformer: (value: any) => PropertyKey = identity
+const defaultKeyTransformer = <V, TK extends PropertyKey>(value: V) => {
+  return value as unknown as TK;
+};
+
+export const invert = <
+  K extends PropertyKey,
+  V,
+  TK extends PropertyKey = V extends PropertyKey ? V : PropertyKey
+>(
+  obj: Record<K, V>,
+  keyTransformer: (value: V) => TK = defaultKeyTransformer<V, TK>
 ) => {
-  const invertedObj: Record<PropertyKey, any> = {};
+  const invertedObj = {} as Record<TK, K>;
 
-  Object.keys(obj).forEach((key) => {
-    const value = obj[key];
-    invertedObj[keyTransformer(value)] = key;
-  });
+  for (const key in obj) {
+    if (hasProperty(obj, key)) {
+      const value = obj[key];
+      const transformedKey = keyTransformer(value);
+
+      invertedObj[transformedKey] = key;
+    }
+  }
 
   return invertedObj;
 };

--- a/packages/utils/src/object/invert/index.ts
+++ b/packages/utils/src/object/invert/index.ts
@@ -1,5 +1,3 @@
-import { hasProperty } from '../../validator';
-
 const defaultKeyTransformer = <V, TK extends PropertyKey>(value: V) => {
   return value as unknown as TK;
 };
@@ -12,16 +10,15 @@ export const invert = <
   obj: Record<K, V>,
   keyTransformer: (value: V) => TK = defaultKeyTransformer<V, TK>
 ) => {
-  const invertedObj = {} as Record<TK, K>;
+  const invertedObj = {} as Record<TK, Exclude<K, symbol>>;
+  const keys = Object.keys(obj) as Exclude<K, symbol>[];
 
-  for (const key in obj) {
-    if (hasProperty(obj, key)) {
-      const value = obj[key];
-      const transformedKey = keyTransformer(value);
+  keys.forEach((key) => {
+    const value = obj[key];
+    const transformedKey = keyTransformer(value);
 
-      invertedObj[transformedKey] = key;
-    }
-  }
+    invertedObj[transformedKey] = key;
+  });
 
   return invertedObj;
 };

--- a/packages/utils/src/object/invert/invert.spec.ts
+++ b/packages/utils/src/object/invert/invert.spec.ts
@@ -39,6 +39,16 @@ describe('invert', () => {
     expectTypeOf(result).toEqualTypeOf<Record<'foo' | 'bar', 'a' | 'b'>>();
   });
 
+  it('should exclude keys that contain symbols.', () => {
+    const symbol = Symbol(1);
+
+    const obj = { [symbol]: 1, foo: 2 } as const;
+    const result = invert(obj);
+
+    expect(result).toEqual({ 2: 'foo' });
+    expectTypeOf(result).toEqualTypeOf<Record<1 | 2, 'foo'>>();
+  });
+
   it('should handle an empty object', () => {
     const obj = {};
     const result = invert(obj);

--- a/packages/utils/src/object/invert/invert.spec.ts
+++ b/packages/utils/src/object/invert/invert.spec.ts
@@ -6,14 +6,37 @@ describe('invert', () => {
     const result = invert(obj);
 
     expect(result).toEqual({ 1: 'a', 2: 'b', 3: 'c' });
+    expectTypeOf(result).toEqualTypeOf<Record<number, 'a' | 'b' | 'c'>>();
   });
 
-  it('should use the keyTransformer if provided', () => {
+  it('should use the keyTransformer if provided(1)', () => {
     const obj = { a: 1, b: 2, c: 3 };
-    const keyTransformer = (value: number) => `key_${value}`;
+    const keyTransformer = (value: number): `key_${number}` => `key_${value}`;
     const result = invert(obj, keyTransformer);
 
     expect(result).toEqual({ key_1: 'a', key_2: 'b', key_3: 'c' });
+    expectTypeOf(result).toEqualTypeOf<
+      Record<`key_${number}`, 'a' | 'b' | 'c'>
+    >();
+  });
+
+  it('should use the keyTransformer if provided(2)', () => {
+    const obj = { a: [1, 2, 3], b: [1, 2, 3], c: [1, 2, 3] } as const;
+    const result = invert(obj, (value) => value[0]);
+
+    expect(result).toEqual({ 1: 'c' });
+    expectTypeOf(result).toEqualTypeOf<Record<1, 'a' | 'b' | 'c'>>();
+  });
+
+  it('should use the keyTransformer if provided(3)', () => {
+    const obj = {
+      a: { name: 'foo' },
+      b: { name: 'bar' },
+    } as const;
+    const result = invert(obj, (value) => value.name);
+
+    expect(result).toEqual({ foo: 'a', bar: 'b' });
+    expectTypeOf(result).toEqualTypeOf<Record<'foo' | 'bar', 'a' | 'b'>>();
   });
 
   it('should handle an empty object', () => {


### PR DESCRIPTION
## Overview

invert가 조금 더 명확한 타입을 추론하기 위해 타입을 개선하였습니다.
이제 invert함수가 조금 더 명확한 타입을 추론할 수 있습니다.

### Case1
```ts
// as-is
const obj = {
  a: { name: 'foo' },
  b: { name: 'bar' },
} as const;

const result = invert(obj, (value) => value.name);
// const result: Record<PropertyKey, any>
```
```ts
// to-be
const obj = {
  a: { name: 'foo' },
  b: { name: 'bar' },
} as const;

const result = invert(obj, (value) => value.name);
// const result: Record<'foo' | 'bar', 'a' | 'b'>
```

<br />

### Case2
```ts
// as-is
const obj = { a: 1, b: 2, c: 3 };
const keyTransformer = (value: number): `key_${number}` => `key_${value}`;

const result = invert(obj, keyTransformer);
// const result: Record<PropertyKey, any>
```
```ts
// to-be
const obj = { a: 1, b: 2, c: 3 };
const keyTransformer = (value: number): `key_${number}` => `key_${value}`;

const result = invert(obj, keyTransformer);
// const result: Record<`key_${number}`, "a" | "b" | "c">
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)