### PR TITLE
feat(utils): uniq 신규 유틸 함수 추가

### DIFF
--- a/.changeset/shaggy-planes-develop.md
+++ b/.changeset/shaggy-planes-develop.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): uniq 신규 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/array/uniq.md
+++ b/docs/docs/utils/array/uniq.md
@@ -1,0 +1,48 @@
+# uniq
+
+`중복 요소를 제외한 배열`을 반환하는 함수입니다.
+
+기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 2번째 인자인 `iteratee` 함수 결과로 중복 요소임을 판단 할 수 있습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/uniq/index.ts)
+
+## Interface
+```ts title="typescript"
+const uniq: <T, U = T>(
+  arr: T[] | readonly T[],
+  iteratee?: ((item: T) => U) | undefined
+) => T[];
+```
+
+## Usage
+### Default
+```ts title="typescript"
+import { uniq } from '@modern-kit/utils';
+
+uniq([1, 2, 3]); // [1, 2, 3] 
+uniq([1, 2, 2, 2, 3]); // [1, 2, 3]
+```
+
+### Iteratee
+```ts title="typescript"
+import { uniq } from '@modern-kit/utils';
+
+const testArr = [
+  { id: 1, name: 'John' },
+  { id: 2, name: 'Jane' },
+  { id: 1, name: 'John' },
+];
+
+uniq(testArr, (item) => item.id === 1);
+/*
+  [
+    { id: 1, name: 'John' },
+    { id: 2, name: 'Jane' },
+  ];
+*/
+
+uniq([1, 2, 2.1, 2.2, 2.3, 3], (item) => Math.floor(item)); // [1, 2, 3]
+```

--- a/packages/utils/src/array/index.ts
+++ b/packages/utils/src/array/index.ts
@@ -3,3 +3,4 @@ export * from './contain';
 export * from './countOccurrencesInArray';
 export * from './excludeElements';
 export * from './partition';
+export * from './uniq';

--- a/packages/utils/src/array/uniq/index.ts
+++ b/packages/utils/src/array/uniq/index.ts
@@ -1,0 +1,22 @@
+export const uniq = <T, U = T>(
+  arr: T[] | readonly T[],
+  iteratee?: (item: T) => U
+) => {
+  if (!iteratee) {
+    return Array.from(new Set(arr));
+  }
+
+  const set = new Set<U>();
+  const result: T[] = [];
+
+  for (const item of arr) {
+    const appliedIterateeItem = iteratee(item);
+
+    if (set.has(appliedIterateeItem)) continue;
+
+    set.add(appliedIterateeItem);
+    result.push(item);
+  }
+
+  return result;
+};

--- a/packages/utils/src/array/uniq/uniq.spec.ts
+++ b/packages/utils/src/array/uniq/uniq.spec.ts
@@ -1,0 +1,53 @@
+import { uniq } from '.';
+
+describe('uniq', () => {
+  it('should return the same array if there are no duplicates', () => {
+    const testArr = [1, 2, 3];
+    const expectedArray = [1, 2, 3];
+
+    expect(uniq(testArr)).toEqual(expectedArray);
+  });
+
+  it('should return an array with duplicates removed', () => {
+    const testArr = [1, 2, 2, 'a', 2, 'a', 3];
+    const expectedArray = [1, 2, 'a', 3];
+
+    expect(uniq(testArr)).toEqual(expectedArray);
+  });
+
+  it('should be able to determine duplicate elements based on the results of the iteratee(Array)', () => {
+    const testArr = [1, 2, 2.1, 2.2, 2.3, 3];
+    const expectedArray = [1, 2, 3];
+
+    expect(uniq(testArr, (item) => Math.floor(item))).toEqual(expectedArray);
+  });
+
+  it('should be able to determine duplicate elements based on the results of the iteratee(Nested Array)', () => {
+    const testArr = [
+      ['a', 'b', 'c'],
+      ['a', 'b', 'c'],
+      ['a', 'b', 'c'],
+    ];
+    const expectedArray = [['a', 'b', 'c']];
+
+    expect(uniq(testArr)).toEqual(testArr); // no iteratee
+    expect(uniq(testArr, (item) => JSON.stringify(item))).toEqual(
+      expectedArray
+    );
+  });
+
+  it('should be able to determine duplicate elements based on the results of the iteratee(Object)', () => {
+    const testArr = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+      { id: 1, name: 'John' },
+    ];
+    const expectedArray = [
+      { id: 1, name: 'John' },
+      { id: 2, name: 'Jane' },
+    ];
+
+    expect(uniq(testArr)).toEqual(testArr); // no iteratee
+    expect(uniq(testArr, (item) => item.id === 1)).toEqual(expectedArray);
+  });
+});


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/222

`중복 요소를 제외한 배열`을 반환하는 함수입니다.

기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 2번째 인자인 `iteratee` 함수 결과로 중복 요소임을 판단 할 수 있습니다.

```ts
uniq([1, 2, 3]); // [1, 2, 3] 
uniq([1, 2, 2, 2, 3]); // [1, 2, 3] 
```
```ts
const testArr = [
  { id: 1, name: 'John' },
  { id: 2, name: 'Jane' },
  { id: 1, name: 'John' },
];

uniq(testArr, (item) => item.id === 1);
/*
  [
    { id: 1, name: 'John' },
    { id: 2, name: 'Jane' },
  ];
*/

uniq([1, 2, 2.1, 2.2, 2.3, 3], (item) => Math.floor(item)); // [1, 2, 3]
```


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)