### PR TITLE
feat(react): useVhProperty 훅 추가 완료

### DIFF
--- a/.changeset/lovely-geese-turn.md
+++ b/.changeset/lovely-geese-turn.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": minor
+---
+
+feat(react): useVhProperty 훅 추가 완료 - @sangminnn

--- a/docs/docs/react/hooks/useVhProperty.mdx
+++ b/docs/docs/react/hooks/useVhProperty.mdx
@@ -7,7 +7,7 @@ iOS 웹 환경에서는 주소표시줄의 높이로 인해 100vh가 실제 보�
 
 이를 해결하기 위해 `useVhProperty` 훅을 사용하면 `100vh`를 실제 화면의 높이로 계산할 수 있도록 css변수를 설정할 수 있습니다.
 
-일반적으로 iOS 환경에서 resize는 가로/세로 전환시에만 발생하지만, 두번째 인자의 calculateAtResize를 옵션을 사용하면 iOS 환경에서도 resize 이벤트가 발생할 때마다 css변수를 다시 계산할 수 있습니다.
+일반적으로 iOS 환경에서 resize는 가로/세로 전환시에만 발생하지만, 두번째 인자의 enableResize를 옵션을 사용하면 iOS 환경에서도 resize 이벤트가 발생할 때마다 css변수를 다시 계산할 수 있습니다.
 
 <br />
 
@@ -18,7 +18,7 @@ iOS 웹 환경에서는 주소표시줄의 높이로 인해 100vh가 실제 보�
 ```ts title="typescript"
 
 interface Options {
-  calculateAtResize?: boolean;
+  enableResize?: boolean;
 }
 
 const useVhProperty: (name?: string, options?: Options) => void

--- a/docs/docs/react/hooks/useVhProperty.mdx
+++ b/docs/docs/react/hooks/useVhProperty.mdx
@@ -1,0 +1,78 @@
+import { useMemo } from 'react';
+import { useVhProperty } from '@modern-kit/react';
+
+# useVhProperty
+
+iOS 웹 환경에서는 주소표시줄의 높이로 인해 100vh가 실제 보이는 화면의 높이보다 크게 측정됩니다.
+
+이를 해결하기 위해 `useVhProperty` 훅을 사용하면 `100vh`를 실제 화면의 높이로 계산할 수 있도록 css변수를 설정할 수 있습니다.
+
+일반적으로 iOS 환경에서 resize는 가로/세로 전환시에만 발생하지만, 두번째 인자의 calculateAtResize를 옵션을 사용하면 iOS 환경에서도 resize 이벤트가 발생할 때마다 css변수를 다시 계산할 수 있습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useVhProperty/index.ts)
+
+## Interface
+```ts title="typescript"
+
+interface Options {
+  calculateAtResize?: boolean;
+}
+
+const useVhProperty: (name?: string, options?: Options) => void
+
+```
+
+## Usage
+```tsx title="typescript"
+import { useVhProperty } from '@modern-kit/react';
+
+const Example = () => {
+  useVhProperty()
+
+  const style = useMemo(() => {
+    return {
+      height: 'calc(var(--vh, 1vh) * 100)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'purple',
+      fontSize: '2rem',
+      color: '#fff',
+    }
+  }, []);
+
+  return (
+    <div style={style}>
+      100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.
+    </div>
+  );
+};
+```
+
+## Example
+export const Example = () => {
+  useVhProperty()
+
+  const style = useMemo(() => {
+    return {
+      height: 'calc(var(--vh, 1vh) * 100)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      background: 'purple',
+      fontSize: '2rem',
+      color: '#fff',
+    }
+  }, []);
+
+  return (
+    <div style={style}>
+      100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.
+    </div>
+  );
+};
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -26,6 +26,7 @@ export * from './useScrollLock';
 export * from './useTimeout';
 export * from './useToggle';
 export * from './useUnMount';
+export * from './useVhProperty';
 export * from './useVisibilityChange';
 export * from './useWindowScrollTo';
 export * from './useWindowSize';

--- a/packages/react/src/hooks/useVhProperty/index.ts
+++ b/packages/react/src/hooks/useVhProperty/index.ts
@@ -1,16 +1,14 @@
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
-import { usePrevious } from '../usePrevious';
 
 interface Options {
-  calculateAtResize?: boolean;
+  enableResize?: boolean;
 }
 
 export const useVhProperty = (
   name: string = 'vh',
-  options: Options = { calculateAtResize: false },
+  options: Options = { enableResize: false },
 ) => {
-  const previousName = usePrevious(name);
-  const { calculateAtResize } = options;
+  const { enableResize } = options;
 
   useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
@@ -18,20 +16,16 @@ export const useVhProperty = (
       document.documentElement.style.setProperty(`--${name}`, `${vh}px`);
     };
 
-    if (previousName !== name) {
-      document.documentElement.style.removeProperty(`--${previousName}`);
-    }
-
     handleResize();
 
-    if (calculateAtResize) {
+    if (enableResize) {
       window.addEventListener('resize', handleResize);
     }
 
     return () => {
-      if (calculateAtResize) {
+      if (enableResize) {
         window.removeEventListener('resize', handleResize);
       }
     };
-  }, [name, calculateAtResize]);
+  }, [name, enableResize]);
 };

--- a/packages/react/src/hooks/useVhProperty/index.ts
+++ b/packages/react/src/hooks/useVhProperty/index.ts
@@ -1,0 +1,37 @@
+import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
+import { usePrevious } from '../usePrevious';
+
+interface Options {
+  calculateAtResize?: boolean;
+}
+
+export const useVhProperty = (
+  name: string = 'vh',
+  options: Options = { calculateAtResize: false },
+) => {
+  const previousName = usePrevious(name);
+  const { calculateAtResize } = options;
+
+  useIsomorphicLayoutEffect(() => {
+    const handleResize = () => {
+      const vh = window.innerHeight * 0.01;
+      document.documentElement.style.setProperty(`--${name}`, `${vh}px`);
+    };
+
+    if (previousName !== name) {
+      document.documentElement.style.removeProperty(`--${previousName}`);
+    }
+
+    handleResize();
+
+    if (calculateAtResize) {
+      window.addEventListener('resize', handleResize);
+    }
+
+    return () => {
+      if (calculateAtResize) {
+        window.removeEventListener('resize', handleResize);
+      }
+    };
+  }, [name, calculateAtResize]);
+};

--- a/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
+++ b/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
@@ -16,31 +16,11 @@ describe('useVhProperty', () => {
     );
   });
 
-  it('should remove previous property when variable name is changed', () => {
-    window.innerHeight = 800;
-    let variable = 'vh';
-
-    const { rerender } = renderHook(() =>
-      useVhProperty(variable, {
-        calculateAtResize: true,
-      }),
-    );
-    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');
-
-    variable = 'custom';
-    rerender();
-
-    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('');
-    expect(document.documentElement.style.getPropertyValue('--custom')).toBe(
-      '8px',
-    );
-  });
-
   it('should set --vh property on documentElement and update on resize', () => {
     window.innerHeight = 800;
     renderHook(() =>
       useVhProperty('vh', {
-        calculateAtResize: true,
+        enableResize: true,
       }),
     );
     expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');

--- a/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
+++ b/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
@@ -1,0 +1,53 @@
+import { renderHook } from '@testing-library/react';
+import { useVhProperty } from '.';
+
+describe('useVhProperty', () => {
+  it('should set --vh property on documentElement', () => {
+    window.innerHeight = 800;
+    renderHook(() => useVhProperty());
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');
+  });
+
+  it('should set --custom property on documentElement', () => {
+    window.innerHeight = 800;
+    renderHook(() => useVhProperty('custom'));
+    expect(document.documentElement.style.getPropertyValue('--custom')).toBe(
+      '8px',
+    );
+  });
+
+  it('should remove previous property when variable name is changed', () => {
+    window.innerHeight = 800;
+    let variable = 'vh';
+
+    const { rerender } = renderHook(() =>
+      useVhProperty(variable, {
+        calculateAtResize: true,
+      }),
+    );
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');
+
+    variable = 'custom';
+    rerender();
+
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('');
+    expect(document.documentElement.style.getPropertyValue('--custom')).toBe(
+      '8px',
+    );
+  });
+
+  it('should set --vh property on documentElement and update on resize', () => {
+    window.innerHeight = 800;
+    renderHook(() =>
+      useVhProperty('vh', {
+        calculateAtResize: true,
+      }),
+    );
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');
+
+    window.innerHeight = 600;
+    window.dispatchEvent(new Event('resize'));
+
+    expect(document.documentElement.style.getPropertyValue('--vh')).toBe('6px');
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #148 

iOS환경에서 주소표시줄의 높이로 인해 100vh가 실제 보이는 화면의 높이보다 크게 측정되는 이슈를 해결하기 위해, 아래의 훅을 사용하여 주소표시줄의 높이를 제외한 height를 계산할 수 있도록 css변수를 설정해주는 훅입니다.

(이슈를 가지고간 후로 작업까지 너무 오래걸렸습니다 송구합니다 😂 )

## PR Checklist
- [O] All tests pass.
- [O] All type checks pass.
- [O] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)