### PR TITLE
feat(utils): union 유틸 함수 추가 및 ArrayWithReadonly 유틸 타입 추가

### DIFF
--- a/.changeset/lazy-years-change.md
+++ b/.changeset/lazy-years-change.md
@@ -1,0 +1,6 @@
+---
+'@modern-kit/types': minor
+'@modern-kit/utils': minor
+---
+
+feat(utils): union 유틸 함수 추가 및 ArrayWithReadonly 유틸 타입 추가 - @ssi02014

--- a/docs/docs/utils/array/contain.md
+++ b/docs/docs/utils/array/contain.md
@@ -32,10 +32,8 @@ Object.is(NaN, 0 / 0); // true
 ## Interface
 
 ```ts title="typescript"
-type ArrayWithReadonly<T> = T[] | readonly T[]
-
 const contain: <T>(
-  arr: ArrayWithReadonly<T>,
+  arr: T[] | readonly T[],
   value: unknown,
   comparator?: (x: any, y: any) => boolean
 ) => value is T;

--- a/docs/docs/utils/array/contain.md
+++ b/docs/docs/utils/array/contain.md
@@ -32,10 +32,12 @@ Object.is(NaN, 0 / 0); // true
 ## Interface
 
 ```ts title="typescript"
+type ArrayWithReadonly<T> = T[] | readonly T[]
+
 const contain: <T>(
-  arr: readonly T[] | T[],
+  arr: ArrayWithReadonly<T>,
   value: unknown,
-  comparator?: (x: any, y: any) => boolean // default: Object.is
+  comparator?: (x: any, y: any) => boolean
 ) => value is T;
 ```
 

--- a/docs/docs/utils/array/excludeElements.md
+++ b/docs/docs/utils/array/excludeElements.md
@@ -13,10 +13,12 @@
 
 ## Interface
 ```ts title="typescript"
-const excludeElements = <E, U extends E>(
-  array: ReadonlyArray<E> | Array<E>,
-  ...args: ReadonlyArray<U> | Array<U>
-) => Array<E>
+type ArrayWithReadonly<T> = T[] | readonly T[]
+
+const excludeElements: <T, U extends T>(
+  array: ArrayWithReadonly<T>,
+  ...args: ArrayWithReadonly<U>
+) => T[];
 ```
 
 ## Usage

--- a/docs/docs/utils/array/excludeElements.md
+++ b/docs/docs/utils/array/excludeElements.md
@@ -13,11 +13,9 @@
 
 ## Interface
 ```ts title="typescript"
-type ArrayWithReadonly<T> = T[] | readonly T[]
-
 const excludeElements: <T, U extends T>(
-  array: ArrayWithReadonly<T>,
-  ...args: ArrayWithReadonly<U>
+  array: T[] | readonly T[],
+  ...args: U[] | readonly U[]
 ) => T[];
 ```
 

--- a/docs/docs/utils/array/partition.md
+++ b/docs/docs/utils/array/partition.md
@@ -10,7 +10,7 @@
 ## Interface
 ```ts title="typescript"
 const partition: <T>(
-  arr: readonly T[] | T[],
+  arr: T[] | readonly T[],
   predicate: (item: T) => boolean
 ) => [truthyArray: T[], falsyArray: T[]];
 ```

--- a/docs/docs/utils/array/union.md
+++ b/docs/docs/utils/array/union.md
@@ -11,11 +11,9 @@
 
 ## Interface
 ```ts title="typescript"
-type ArrayWithReadonly<T> = T[] | readonly T[]
-
 const union: <T, U = T>(
-  arr1: ArrayWithReadonly<T>,
-  arr2: ArrayWithReadonly<T>,
+  arr1: T[] | readonly T[],
+  arr2: T[] | readonly T[],
   iteratee?: ((item: T) => U) | undefined
 ) => T[];
 ```

--- a/docs/docs/utils/array/union.md
+++ b/docs/docs/utils/array/union.md
@@ -1,0 +1,52 @@
+# union
+
+두 배열을 결합 후, `중복 요소를 제외해 고유한 값만을 갖는` 새로운 배열을 반환하는 함수입니다.
+
+기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 3번째 인자인 `iteratee` 함수 결과로 중복 요소임을 판단 할 수 있습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/union/index.ts)
+
+## Interface
+```ts title="typescript"
+type ArrayWithReadonly<T> = T[] | readonly T[]
+
+const union: <T, U = T>(
+  arr1: ArrayWithReadonly<T>,
+  arr2: ArrayWithReadonly<T>,
+  iteratee?: ((item: T) => U) | undefined
+) => T[];
+```
+
+## Usage
+### Default
+```ts title="typescript"
+import { union } from '@modern-kit/utils';
+
+union([1, 2, 3, 4], [1, 2, 3, 5]); // [1, 2, 3, 4, 5] 
+```
+
+### Iteratee
+```ts title="typescript"
+import { union } from '@modern-kit/utils';
+
+const arr1 = [
+  { id: 1, name: 'john' },
+  { id: 2, name: 'jane' },
+];
+const arr2 = [
+  { id: 1, name: 'john' },
+  { id: 3, name: 'gromit' },
+];
+
+union(arr1, arr2, (item) => item.id);
+/*
+  [
+    { id: 1, name: 'john' },
+    { id: 2, name: 'jane' },
+    { id: 3, name: 'gromit' }
+  ]
+*/
+```

--- a/docs/docs/utils/array/uniq.md
+++ b/docs/docs/utils/array/uniq.md
@@ -11,10 +11,8 @@
 
 ## Interface
 ```ts title="typescript"
-type ArrayWithReadonly<T> = T[] | readonly T[]
-
 const uniq: <T, U = T>(
-  arr: ArrayWithReadonly<T>,
+  arr: T[] | readonly T[],
   iteratee?: ((item: T) => U) | undefined
 ) => T[];
 ```

--- a/docs/docs/utils/array/uniq.md
+++ b/docs/docs/utils/array/uniq.md
@@ -1,6 +1,6 @@
 # uniq
 
-`중복 요소를 제외한 배열`을 반환하는 함수입니다.
+`중복 요소를 제외해 고유한 값만을 갖는` 새로운 배열을 반환하는 함수입니다.
 
 기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 2번째 인자인 `iteratee` 함수 결과로 중복 요소임을 판단 할 수 있습니다.
 
@@ -11,8 +11,10 @@
 
 ## Interface
 ```ts title="typescript"
+type ArrayWithReadonly<T> = T[] | readonly T[]
+
 const uniq: <T, U = T>(
-  arr: T[] | readonly T[],
+  arr: ArrayWithReadonly<T>,
   iteratee?: ((item: T) => U) | undefined
 ) => T[];
 ```

--- a/docs/docs/utils/array/uniq.md
+++ b/docs/docs/utils/array/uniq.md
@@ -34,13 +34,16 @@ const testArr = [
   { id: 1, name: 'John' },
   { id: 2, name: 'Jane' },
   { id: 1, name: 'John' },
+  { id: 3, name: 'gromit' },
+  { id: 3, name: 'gromit' },
 ];
 
-uniq(testArr, (item) => item.id === 1);
+uniq(testArr, (item) => item.id);
 /*
   [
     { id: 1, name: 'John' },
     { id: 2, name: 'Jane' },
+    { id: 3, name: 'gromit' }
   ];
 */
 

--- a/packages/types/src/ArrayWithReadonly/index.ts
+++ b/packages/types/src/ArrayWithReadonly/index.ts
@@ -1,0 +1,1 @@
+export type ArrayWithReadonly<T> = T[] | readonly T[];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,6 +9,7 @@ export * from './ObjectEntries';
 export * from './ObjectKeys';
 export * from './Primitive';
 export * from './Promiseable';
+export * from './ArrayWithReadonly';
 export * from './Integer';
 export * from './Reference';
 export * from './NaturalNumber';

--- a/packages/utils/src/array/contain/index.ts
+++ b/packages/utils/src/array/contain/index.ts
@@ -1,5 +1,7 @@
+import { ArrayWithReadonly } from '@modern-kit/types';
+
 export const contain = <T>(
-  arr: T[] | ReadonlyArray<T>,
+  arr: ArrayWithReadonly<T>,
   value: unknown,
   comparator: (x: any, y: any) => boolean = Object.is
 ): value is T => {

--- a/packages/utils/src/array/contain/index.ts
+++ b/packages/utils/src/array/contain/index.ts
@@ -1,7 +1,5 @@
-import { ArrayWithReadonly } from '@modern-kit/types';
-
 export const contain = <T>(
-  arr: ArrayWithReadonly<T>,
+  arr: T[] | readonly T[],
   value: unknown,
   comparator: (x: any, y: any) => boolean = Object.is
 ): value is T => {

--- a/packages/utils/src/array/excludeElements/index.ts
+++ b/packages/utils/src/array/excludeElements/index.ts
@@ -1,7 +1,9 @@
-export const excludeElements = <E, U extends E>(
-  array: ReadonlyArray<E> | Array<E>,
-  ...args: ReadonlyArray<U> | Array<U>
-): Array<E> => {
+import { ArrayWithReadonly } from '@modern-kit/types';
+
+export const excludeElements = <T, U extends T>(
+  array: ArrayWithReadonly<T>,
+  ...args: ArrayWithReadonly<U>
+) => {
   const excludeSet = new Set(args.map((arg) => JSON.stringify(arg)));
 
   return array.filter((element) => !excludeSet.has(JSON.stringify(element)));

--- a/packages/utils/src/array/excludeElements/index.ts
+++ b/packages/utils/src/array/excludeElements/index.ts
@@ -1,8 +1,6 @@
-import { ArrayWithReadonly } from '@modern-kit/types';
-
 export const excludeElements = <T, U extends T>(
-  array: ArrayWithReadonly<T>,
-  ...args: ArrayWithReadonly<U>
+  array: T[] | readonly T[],
+  ...args: T[] | readonly U[]
 ) => {
   const excludeSet = new Set(args.map((arg) => JSON.stringify(arg)));
 

--- a/packages/utils/src/array/partition/index.ts
+++ b/packages/utils/src/array/partition/index.ts
@@ -1,5 +1,5 @@
 export const partition = <T>(
-  arr: T[] | ReadonlyArray<T>,
+  arr: T[] | readonly T[],
   predicate: (item: T) => boolean
 ): [truthyArray: T[], falsyArray: T[]] => {
   const truthyArray: T[] = [];

--- a/packages/utils/src/array/union/index.ts
+++ b/packages/utils/src/array/union/index.ts
@@ -1,9 +1,8 @@
-import { ArrayWithReadonly } from '@modern-kit/types';
 import { uniq } from '../uniq';
 
 export const union = <T, U = T>(
-  arr1: ArrayWithReadonly<T>,
-  arr2: ArrayWithReadonly<T>,
+  arr1: T[] | readonly T[],
+  arr2: T[] | readonly T[],
   iteratee?: (item: T) => U
 ) => {
   return uniq(arr1.concat(arr2), iteratee);

--- a/packages/utils/src/array/union/index.ts
+++ b/packages/utils/src/array/union/index.ts
@@ -1,0 +1,10 @@
+import { ArrayWithReadonly } from '@modern-kit/types';
+import { uniq } from '../uniq';
+
+export const union = <T, U = T>(
+  arr1: ArrayWithReadonly<T>,
+  arr2: ArrayWithReadonly<T>,
+  iteratee?: (item: T) => U
+) => {
+  return uniq(arr1.concat(arr2), iteratee);
+};

--- a/packages/utils/src/array/union/union.spec.ts
+++ b/packages/utils/src/array/union/union.spec.ts
@@ -1,0 +1,36 @@
+import { union } from '.';
+
+describe('union', () => {
+  it('should combine two arrays and remove duplicates', () => {
+    const arr1 = [1, 2, 3, 4];
+    const arr2 = [1, 2, 4, 5];
+
+    expect(union(arr1, arr2)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should use iteratee to determine uniqueness', () => {
+    const arr1 = [
+      { id: 1, name: 'john' },
+      { id: 2, name: 'jane' },
+    ];
+    const arr2 = [
+      { id: 1, name: 'john' },
+      { id: 3, name: 'gromit' },
+    ];
+
+    expect(union(arr1, arr2, (item) => item.id)).toEqual([
+      { id: 1, name: 'john' },
+      { id: 2, name: 'jane' },
+      { id: 3, name: 'gromit' },
+    ]);
+  });
+
+  it('should correctly infer types while combining arrays and removing duplicates', () => {
+    const arr1 = [1, 2, 3, 4] as const;
+    const arr2 = [1, 2, 4, 5] as const;
+
+    const unionArray = union(arr1, arr2);
+    expect(unionArray).toEqual([1, 2, 3, 4, 5]);
+    expectTypeOf(unionArray).toEqualTypeOf<(1 | 2 | 3 | 4 | 5)[]>();
+  });
+});

--- a/packages/utils/src/array/uniq/index.ts
+++ b/packages/utils/src/array/uniq/index.ts
@@ -1,5 +1,7 @@
+import { ArrayWithReadonly } from '@modern-kit/types';
+
 export const uniq = <T, U = T>(
-  arr: T[] | readonly T[],
+  arr: ArrayWithReadonly<T>,
   iteratee?: (item: T) => U
 ) => {
   if (!iteratee) {

--- a/packages/utils/src/array/uniq/index.ts
+++ b/packages/utils/src/array/uniq/index.ts
@@ -1,7 +1,5 @@
-import { ArrayWithReadonly } from '@modern-kit/types';
-
 export const uniq = <T, U = T>(
-  arr: ArrayWithReadonly<T>,
+  arr: T[] | readonly T[],
   iteratee?: (item: T) => U
 ) => {
   if (!iteratee) {

--- a/packages/utils/src/array/uniq/uniq.spec.ts
+++ b/packages/utils/src/array/uniq/uniq.spec.ts
@@ -41,13 +41,16 @@ describe('uniq', () => {
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
       { id: 1, name: 'John' },
+      { id: 3, name: 'gromit' },
+      { id: 3, name: 'gromit' },
     ];
     const expectedArray = [
       { id: 1, name: 'John' },
       { id: 2, name: 'Jane' },
+      { id: 3, name: 'gromit' },
     ];
 
     expect(uniq(testArr)).toEqual(testArr); // no iteratee
-    expect(uniq(testArr, (item) => item.id === 1)).toEqual(expectedArray);
+    expect(uniq(testArr, (item) => item.id)).toEqual(expectedArray);
   });
 });


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/210

두 배열을 결합 후, `중복 요소를 제외해 고유한 값만을 갖는` 새로운 배열을 반환하는 함수입니다.

기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 3번째 인자인 `iteratee` 함수 결과로 중복 요소임을 판단 할 수 있습니다.

```ts
union([1, 2, 3, 4], [1, 2, 3, 5]); // [1, 2, 3, 4, 5] 
```
```ts
const arr1 = [
  { id: 1, name: 'john' },
  { id: 2, name: 'jane' },
];
const arr2 = [
  { id: 1, name: 'john' },
  { id: 3, name: 'gromit' },
];

union(arr1, arr2, (item) => item.id);
/*
  [
    { id: 1, name: 'john' },
    { id: 2, name: 'jane' },
    { id: 3, name: 'gromit' }
  ]
*/
```

<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)