### PR TITLE
fix(react): LazyImage 내부 스타일 제거

### DIFF
--- a/.changeset/unlucky-turtles-look.md
+++ b/.changeset/unlucky-turtles-look.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+fix(react): LazyImage 내부 스타일 제거 - @ssi02014

--- a/docs/docs/react/components/LazyImage.mdx
+++ b/docs/docs/react/components/LazyImage.mdx
@@ -2,9 +2,7 @@ import { LazyImage } from '@modern-kit/react';
 
 # LazyImage
 
-**[useIntersectionObserver](https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useIntersectionObserver)**를 활용해 `Viewport`에 노출될 때 할당된 이미지를 `Lazy Loading` 하는 이미지 컴포넌트입니다.
-
-`width`, `height` 값을 입력해 이미지의 크기를 조절 할 수 있으며, 동시에 `Layout Shift`를 개선할 수 있습니다.
+**[useIntersectionObserver](https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useIntersectionObserver)** 를 활용해 `Viewport`에 노출될 때 할당된 이미지를 `Lazy Loading` 하는 이미지 컴포넌트입니다.
 
 Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
@@ -102,7 +100,7 @@ const Example = () => {
 
 export const Example = () => {
   return (
-    <div style={{ background: '#f8f8f8' }}>
+    <div style={{ background: '#f8f8f8', width: '500px' }}>
       <div
         style={{
           height: '500px',
@@ -112,36 +110,33 @@ export const Example = () => {
         스크롤 해주세요.
       </div>
       <LazyImage
-        width={'100%'}
-        height={400}
         src={
           'https://github.com/Team-Grace/devgrace/assets/64779472/b5640bec-2abc-4205-afbf-ccfd9876a90b'
         }
         alt="img1"
+        height={400}
         onClick={() => console.log('img click1')}
       />
 
       <div style={{ width: '100%', height: '150px' }} />
 
       <LazyImage
-        width={'100%'}
-        height={400}
         src={
           'https://github.com/Team-Grace/devgrace/assets/64779472/207743a7-b29f-4826-bc08-8df0d67e568b'
         }
         alt="img2"
+        height={400}
         onClick={() => console.log('img click2')}
       />
 
       <div style={{ width: '100%', height: '150px' }} />
 
       <LazyImage
-        width={'100%'}
-        height={400}
         src={
           'https://github.com/Team-Grace/devgrace/assets/64779472/d1957ec8-fe87-406e-bfda-fb4ee505b152'
         }
         alt="img3"
+        height={400}
         onClick={() => console.log('img click3')}
       />
     </div>

--- a/packages/react/src/components/LazyImage/index.tsx
+++ b/packages/react/src/components/LazyImage/index.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, forwardRef, useMemo } from 'react';
+import React, { forwardRef } from 'react';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
 import { useMergeRefs } from '../../hooks/useMergeRefs';
 
@@ -24,20 +24,7 @@ export const LazyImage = forwardRef<HTMLImageElement, LazyImageProps>(
       rootMargin,
     });
 
-    const lazyImageStyle: CSSProperties = useMemo(() => {
-      return {
-        display: 'inline-block',
-        ...style,
-      };
-    }, [style]);
-
-    return (
-      <img
-        {...restProps}
-        ref={useMergeRefs(ref, imgRef)}
-        style={lazyImageStyle}
-      />
-    );
+    return <img ref={useMergeRefs(ref, imgRef)} style={style} {...restProps} />;
   }
 );
 


### PR DESCRIPTION
## Overview

컴포넌트 내부적으로 스타일을 제어하는 것은 불 필요하기 때문에 LaztImage 컴포넌트 내부 스타일을 제거합니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)