### PR TITLE
feat(react): useLocalStorage 신규 훅 추가

### DIFF
--- a/.changeset/new-trees-play.md
+++ b/.changeset/new-trees-play.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useLocalStorage 신규 훅 추가 - @ssi02014

--- a/.changeset/ten-files-push.md
+++ b/.changeset/ten-files-push.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': patch
+---
+
+fix(utils): isFunction 개선 - @ssi02014

--- a/docs/docs/react/hooks/useLocalStorage.mdx
+++ b/docs/docs/react/hooks/useLocalStorage.mdx
@@ -4,9 +4,9 @@ import { useLocalStorage } from '@modern-kit/react';
 
 `React v18`부터 지원하는 **[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)** 을 활용해 로컬 스토리지 내의 특정 `key` 데이터를 구독하고, 구독 중인 데이터에 변화가 있을 시 이를 동기화해주는 커스텀 훅입니다.
 
-로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다.
+로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다. 또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
 
-또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
+setState는 값 자체를 넘길 수 있으며, 함수로도 넘길 수 있습니다. 함수로 활용 시에 첫 번째 인자로 state 값을 가져올 수 있습니다.
 
 <br />
 
@@ -22,7 +22,7 @@ interface UseLocalStorageProps<T> {
 
 const useLocalStorage: <T>({ key, initialValue }: UseLocalStorageProps<T>) => {
   readonly state: T | null;
-  readonly setState: (value: T) => void;
+  readonly setState: (value: T | ((state: T | null) => T)) => void;
   readonly removeState: () => void;
 };
 ```

--- a/docs/docs/react/hooks/useLocalStorage.mdx
+++ b/docs/docs/react/hooks/useLocalStorage.mdx
@@ -1,0 +1,84 @@
+import { useLocalStorage } from '@modern-kit/react';
+
+# useLocalStorage
+
+`React v18`부터 지원하는 **[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)** 을 활용해 로컬 스토리지 내의 특정 `key` 데이터를 구독하고, 구독 중인 데이터에 변화가 있을 시 이를 동기화해주는 커스텀 훅입니다.
+
+로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다.
+
+또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useLocalStorage/index.ts)
+
+## Interface
+```ts title="typescript"
+interface UseLocalStorageProps<T> {
+  key: string;
+  initialValue?: T | (() => T) | null;
+}
+
+const useLocalStorage: <T>({ key, initialValue }: UseLocalStorageProps<T>) => {
+  readonly state: T | null;
+  readonly setState: (value: T) => void;
+  readonly removeState: () => void;
+};
+```
+
+## Usage
+```tsx title="typescript"
+import { useLocalStorage } from '@modern-kit/react';
+
+const Example = () => {
+  const { state, setState, removeState } = useLocalStorage({
+    key: 'test',
+    initialValue: 'default',
+  });
+
+  return (
+    <div>
+      <p>개발자 도구에서 로컬 스토리지를 확인해보세요!</p>
+      <p>state: {state}</p>
+      <button onClick={() => setState('foo')}>
+        {`로컬스토리지 "test"key에 "foo"데이터 저장`}
+      </button>
+      <button onClick={() => setState('bar')}>
+        {`로컬스토리지 "test"key에 "bar"데이터 저장`}
+      </button>
+      <button onClick={() => removeState()}>
+        {`로컬스토리지 "test"key 제거`}
+      </button>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const { state, setState, removeState } = useLocalStorage({
+    key: 'test',
+    initialValue: 'default',
+  });
+
+  return (
+    <div>
+      <p>개발자 도구에서 로컬 스토리지를 확인해보세요!</p>
+      <p>state: {state}</p>
+      <button onClick={() => setState('foo')}>
+        {`로컬스토리지 "test"key에 "foo"데이터 저장`}
+      </button>
+      <button onClick={() => setState('bar')}>
+        {`로컬스토리지 "test"key에 "bar"데이터 저장`}
+      </button>
+      <button onClick={() => removeState()}>
+        {`로컬스토리지 "test"key 제거`}
+      </button>
+    </div>
+  );
+};
+
+
+<Example />

--- a/docs/docs/react/hooks/useLocalStorage.mdx
+++ b/docs/docs/react/hooks/useLocalStorage.mdx
@@ -6,7 +6,44 @@ import { useLocalStorage } from '@modern-kit/react';
 
 로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다. 또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
 
-setState는 값 자체를 넘길 수 있으며, 함수로도 넘길 수 있습니다. 함수로 활용 시에 첫 번째 인자로 state 값을 가져올 수 있습니다.
+`setState`는 값 자체를 넘길 수 있으며, 함수도 넘길 수 있습니다. 함수로 활용 시에 인자로 state 값을 가져올 수 있습니다.
+
+```ts
+const { state, setState, removeState } = useLocalStorage<number[]>({
+  key: 'test',
+  initialValue: [1, 2],
+});
+
+setState([1, 2, 3]);
+setState(state => [...state, 3]);
+```
+
+<br />
+
+initialValue를 넘겨주면 더욱 `명확한 타입 추론`이 가능합니다.
+
+```ts
+const { state, setState } = useLocalStorage<number[]>({
+  key: 'test',
+});
+
+state; // number[] | null
+setState(state => {
+  state; // number[] | null
+});
+```
+
+```ts
+const { state, setState } = useLocalStorage<number[]>({
+  key: 'test',
+  initialValue: [],
+});
+
+state; // number[]
+setState(state => {
+  state; // number[]
+});
+```
 
 <br />
 
@@ -15,12 +52,31 @@ setState는 값 자체를 넘길 수 있으며, 함수로도 넘길 수 있습�
 
 ## Interface
 ```ts title="typescript"
-interface UseLocalStorageProps<T> {
+interface UseLocalStorageOptionalInitialValueProps<T> {
   key: string;
   initialValue?: T | (() => T) | null;
 }
 
-const useLocalStorage: <T>({ key, initialValue }: UseLocalStorageProps<T>) => {
+interface UseLocalStorageRequiredInitialValueProps<T> {
+  key: string;
+  initialValue: T | (() => T);
+}
+
+// initialValue 존재하면 state 타입에 null 제외
+function useLocalStorage<T>({
+  key,
+  initialValue,
+}: UseLocalStorageRequiredInitialValue<T>): {
+  readonly state: T;
+  readonly setState: (value: T | ((state: T) => T)) => void;
+  readonly removeState: () => void;
+};
+
+// initialValue 존재하지 않으면 state 타입에 null 포함
+function useLocalStorage<T>({
+  key,
+  initialValue,
+}: UseLocalStorageOptionalInitialValue<T>): {
   readonly state: T | null;
   readonly setState: (value: T | ((state: T | null) => T)) => void;
   readonly removeState: () => void;
@@ -32,7 +88,7 @@ const useLocalStorage: <T>({ key, initialValue }: UseLocalStorageProps<T>) => {
 import { useLocalStorage } from '@modern-kit/react';
 
 const Example = () => {
-  const { state, setState, removeState } = useLocalStorage({
+  const { state, setState, removeState } = useLocalStorage<string>({
     key: 'test',
     initialValue: 'default',
   });

--- a/docs/docs/react/hooks/useLocalStorage.mdx
+++ b/docs/docs/react/hooks/useLocalStorage.mdx
@@ -61,12 +61,14 @@ interface UseLocalStorageRequiredInitialValueProps<T> {
   key: string;
   initialValue: T | (() => T);
 }
-
+```
+```ts
+// 함수 오버로딩
 // initialValue 존재하면 state 타입에 null 제외
 function useLocalStorage<T>({
   key,
   initialValue,
-}: UseLocalStorageRequiredInitialValue<T>): {
+}: UseLocalStorageRequiredInitialValueProps<T>): {
   readonly state: T;
   readonly setState: (value: T | ((state: T) => T)) => void;
   readonly removeState: () => void;
@@ -76,7 +78,7 @@ function useLocalStorage<T>({
 function useLocalStorage<T>({
   key,
   initialValue,
-}: UseLocalStorageOptionalInitialValue<T>): {
+}: UseLocalStorageOptionalInitialValueProps<T>): {
   readonly state: T | null;
   readonly setState: (value: T | ((state: T | null) => T)) => void;
   readonly removeState: () => void;

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -13,6 +13,7 @@ export * from './useInterval';
 export * from './useIsMounted';
 export * from './useIsomorphicLayoutEffect';
 export * from './useKeyDown';
+export * from './useLocalStorage';
 export * from './useMediaQuery';
 export * from './useMergeRefs';
 export * from './useMouse';

--- a/packages/react/src/hooks/useLocalStorage/index.ts
+++ b/packages/react/src/hooks/useLocalStorage/index.ts
@@ -1,10 +1,19 @@
 import { isFunction } from '@modern-kit/utils';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 
-interface UseLocalStorageProps<T> {
+interface UseLocalStorageOptionalInitialValueProps<T> {
   key: string;
   initialValue?: T | (() => T) | null;
 }
+
+interface UseLocalStorageRequiredInitialValueProps<T> {
+  key: string;
+  initialValue: T | (() => T);
+}
+
+type UseLocalStorageProps<T> =
+  | UseLocalStorageOptionalInitialValueProps<T>
+  | UseLocalStorageRequiredInitialValueProps<T>;
 
 const LOCAL_STORAGE_EVENT_KEY = 'local-storage';
 
@@ -36,10 +45,32 @@ const getSnapshot = (key: string) => {
 const getServerSnapshot = <T>(initialValue: T | null) => {
   return JSON.stringify(initialValue);
 };
-export const useLocalStorage = <T>({
+
+// 함수 오버로딩
+// initialValue 존재하면 null 타입 제외
+export function useLocalStorage<T>({
+  key,
+  initialValue,
+}: UseLocalStorageRequiredInitialValueProps<T>): {
+  readonly state: T;
+  readonly setState: (value: T | ((state: T) => T)) => void;
+  readonly removeState: () => void;
+};
+
+// initialValue 존재하지 않으면 null 타입 포함
+export function useLocalStorage<T>({
+  key,
+  initialValue,
+}: UseLocalStorageOptionalInitialValueProps<T>): {
+  readonly state: T | null;
+  readonly setState: (value: T | ((state: T | null) => T)) => void;
+  readonly removeState: () => void;
+};
+
+export function useLocalStorage<T>({
   key,
   initialValue = null,
-}: UseLocalStorageProps<T>) => {
+}: UseLocalStorageProps<T>) {
   useState;
   const initialValueToUse = useMemo(() => {
     return isFunction(initialValue) ? initialValue() : initialValue;
@@ -91,4 +122,4 @@ export const useLocalStorage = <T>({
   }, [key]);
 
   return { state, setState, removeState } as const;
-};
+}

--- a/packages/react/src/hooks/useLocalStorage/index.ts
+++ b/packages/react/src/hooks/useLocalStorage/index.ts
@@ -1,5 +1,4 @@
 import { isFunction } from '@modern-kit/utils';
-import { usePreservedState } from '../usePreservedState';
 import { useCallback, useMemo, useSyncExternalStore } from 'react';
 
 interface UseLocalStorageProps<T> {
@@ -27,9 +26,9 @@ export const useLocalStorage = <T>({
   key,
   initialValue = null,
 }: UseLocalStorageProps<T>) => {
-  const initialValueToUse = usePreservedState(
-    isFunction(initialValue) ? initialValue() : initialValue
-  );
+  const initialValueToUse = useMemo(() => {
+    return isFunction(initialValue) ? initialValue() : initialValue;
+  }, [initialValue]);
 
   const externalStoreState = useSyncExternalStore(
     subscribe,

--- a/packages/react/src/hooks/useLocalStorage/index.ts
+++ b/packages/react/src/hooks/useLocalStorage/index.ts
@@ -1,0 +1,78 @@
+import { isFunction } from '@modern-kit/utils';
+import { usePreservedState } from '../usePreservedState';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+
+interface UseLocalStorageProps<T> {
+  key: string;
+  initialValue?: T | (() => T) | null;
+}
+
+const subscribe = (callback: () => void) => {
+  window.addEventListener('storage', callback);
+  return () => {
+    window.removeEventListener('storage', callback);
+  };
+};
+
+const getSnapshot = (key: string) => {
+  return window.localStorage.getItem(key);
+};
+
+// SSR 환경에서 initialValue를 반환
+const getServerSnapshot = <T>(initialValue: T | null) => {
+  return JSON.stringify(initialValue);
+};
+
+export const useLocalStorage = <T>({
+  key,
+  initialValue = null,
+}: UseLocalStorageProps<T>) => {
+  const initialValueToUse = usePreservedState(
+    isFunction(initialValue) ? initialValue() : initialValue
+  );
+
+  const externalStoreState = useSyncExternalStore(
+    subscribe,
+    () => getSnapshot(key),
+    () => getServerSnapshot(initialValueToUse)
+  );
+
+  const state = useMemo((): T | null => {
+    try {
+      return externalStoreState
+        ? JSON.parse(externalStoreState)
+        : initialValueToUse;
+    } catch (err: any) {
+      throw new Error(
+        `Failed to parse localStorage data for key "${key}": ${err}`
+      );
+    }
+  }, [key, externalStoreState, initialValueToUse]);
+
+  const setState = useCallback(
+    (value: T) => {
+      try {
+        window.localStorage.setItem(key, JSON.stringify(value));
+        window.dispatchEvent(new Event('storage'));
+      } catch (err) {
+        throw new Error(
+          `Failed to store data for key "${key}" in localStorage: ${err}`
+        );
+      }
+    },
+    [key]
+  );
+
+  const removeState = useCallback(() => {
+    try {
+      window.localStorage.removeItem(key);
+      window.dispatchEvent(new Event('storage'));
+    } catch (err) {
+      throw new Error(
+        `Failed to remove key "${key}" from localStorage: ${err}`
+      );
+    }
+  }, [key]);
+
+  return { state, setState, removeState } as const;
+};

--- a/packages/react/src/hooks/useLocalStorage/index.ts
+++ b/packages/react/src/hooks/useLocalStorage/index.ts
@@ -1,5 +1,6 @@
 import { isFunction } from '@modern-kit/utils';
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
+import { getCustomEventHandler } from '../../utils/customEventHandler';
 
 interface UseLocalStorageOptionalInitialValueProps<T> {
   key: string;
@@ -15,20 +16,7 @@ type UseLocalStorageProps<T> =
   | UseLocalStorageOptionalInitialValueProps<T>
   | UseLocalStorageRequiredInitialValueProps<T>;
 
-const LOCAL_STORAGE_EVENT_KEY = 'local-storage';
-
-const localStorageEventHandler = {
-  key: LOCAL_STORAGE_EVENT_KEY,
-  subscribe: (callback: () => void) => {
-    window.addEventListener(LOCAL_STORAGE_EVENT_KEY, callback);
-  },
-  unsubscribe: (callback: () => void) => {
-    window.removeEventListener(LOCAL_STORAGE_EVENT_KEY, callback);
-  },
-  dispatchEvent: () => {
-    window.dispatchEvent(new StorageEvent(LOCAL_STORAGE_EVENT_KEY));
-  },
-};
+const localStorageEventHandler = getCustomEventHandler('localStorage');
 
 const subscribe = (callback: () => void) => {
   localStorageEventHandler.subscribe(callback);

--- a/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
+++ b/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
@@ -33,7 +33,7 @@ describe('useLocalStorage', () => {
     expect(result.current.state).toBe('storedValue');
   });
 
-  it('should update localStorage when state changes', async () => {
+  it('should update localStorage when state changes(1)', async () => {
     const { result } = renderHook(() =>
       useLocalStorage({ key: 'test', initialValue: 'default' })
     );
@@ -44,6 +44,21 @@ describe('useLocalStorage', () => {
 
     expect(result.current.state).toBe('newValue');
     expect(localStorage.getItem('test')).toBe(JSON.stringify('newValue'));
+  });
+
+  it('should update localStorage when state changes(2)', async () => {
+    localStorage.setItem('test', JSON.stringify([1, 2, 3]));
+
+    const { result } = renderHook(() =>
+      useLocalStorage({ key: 'test', initialValue: [1, 2, 3] })
+    );
+
+    await waitFor(() => {
+      result.current.setState((state) => [...(state || []), 4]);
+    });
+
+    expect(result.current.state).toEqual([1, 2, 3, 4]);
+    expect(localStorage.getItem('test')).toBe(JSON.stringify([1, 2, 3, 4]));
   });
 
   it('should remove the value from localStorage', async () => {

--- a/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
+++ b/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
@@ -54,7 +54,7 @@ describe('useLocalStorage', () => {
     );
 
     await waitFor(() => {
-      result.current.setState((state) => [...(state || []), 4]);
+      result.current.setState((state) => [...state, 4]);
     });
 
     expect(result.current.state).toEqual([1, 2, 3, 4]);
@@ -64,7 +64,9 @@ describe('useLocalStorage', () => {
   it('should remove the value from localStorage', async () => {
     localStorage.setItem('test', JSON.stringify('storedValue'));
 
-    const { result } = renderHook(() => useLocalStorage({ key: 'test' }));
+    const { result } = renderHook(() =>
+      useLocalStorage<string>({ key: 'test' })
+    );
 
     await waitFor(() => {
       result.current.removeState();
@@ -83,6 +85,18 @@ describe('useLocalStorage', () => {
     const html = renderToString(<TestComponent />); // server side rendering
 
     expect(html).toContain('ssr');
+  });
+
+  it('should infer the type based on the presence of initialValue', () => {
+    const { result: result1 } = renderHook(() =>
+      useLocalStorage<string>({ key: 'test' })
+    );
+    expectTypeOf(result1.current.state).toEqualTypeOf<string | null>();
+
+    const { result: result2 } = renderHook(() =>
+      useLocalStorage<string>({ key: 'test', initialValue: 'default' })
+    );
+    expectTypeOf(result2.current.state).toEqualTypeOf<string>();
   });
 
   it('should throw an error when localStorage contains invalid JSON', async () => {

--- a/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
+++ b/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
@@ -1,0 +1,100 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useLocalStorage } from '.';
+import { renderToString } from 'react-dom/server';
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('useLocalStorage', () => {
+  it('should initialize with the default value if no value is in localStorage', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    expect(result.current.state).toBe('default');
+  });
+
+  it('should initialize with the default function return value if no value is in localStorage', () => {
+    const { result } = renderHook(() =>
+      useLocalStorage({ key: 'test', initialValue: () => 'default' })
+    );
+
+    expect(result.current.state).toBe('default');
+  });
+
+  it('should initialize with the value from localStorage', () => {
+    localStorage.setItem('test', JSON.stringify('storedValue'));
+
+    const { result } = renderHook(() =>
+      useLocalStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    expect(result.current.state).toBe('storedValue');
+  });
+
+  it('should update localStorage when state changes', async () => {
+    const { result } = renderHook(() =>
+      useLocalStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    await waitFor(() => {
+      result.current.setState('newValue');
+    });
+
+    expect(result.current.state).toBe('newValue');
+    expect(localStorage.getItem('test')).toBe(JSON.stringify('newValue'));
+  });
+
+  it('should remove the value from localStorage', async () => {
+    localStorage.setItem('test', JSON.stringify('storedValue'));
+
+    const { result } = renderHook(() => useLocalStorage({ key: 'test' }));
+
+    await waitFor(() => {
+      result.current.removeState();
+    });
+
+    expect(result.current.state).toBeNull();
+    expect(localStorage.getItem('test')).toBeNull();
+  });
+
+  it('should render initial value during server-side rendering', async () => {
+    const TestComponent = () => {
+      const { state } = useLocalStorage({ key: 'test', initialValue: 'ssr' });
+      return <p>{state}</p>;
+    };
+
+    const html = renderToString(<TestComponent />); // server side rendering
+
+    expect(html).toContain('ssr');
+  });
+
+  it('should throw an error when localStorage contains invalid JSON', async () => {
+    localStorage.setItem('test', "{key: 'value'}");
+
+    expect(() =>
+      renderHook(() => useLocalStorage({ key: 'test' }))
+    ).toThrowError();
+  });
+
+  it('should throw an error when setting an item in localStorage fails', async () => {
+    const { result } = renderHook(() => useLocalStorage({ key: 'test' }));
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error();
+    });
+
+    expect(() => result.current.setState('error')).toThrowError();
+  });
+
+  it('should throw an error when removing an item from localStorage fails', async () => {
+    const { result } = renderHook(() => useLocalStorage({ key: 'test' }));
+
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error();
+    });
+
+    expect(() => result.current.removeState()).toThrowError();
+  });
+});

--- a/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
+++ b/packages/react/src/hooks/useLocalStorage/useLocalStorage.spec.tsx
@@ -73,9 +73,9 @@ describe('useLocalStorage', () => {
   it('should throw an error when localStorage contains invalid JSON', async () => {
     localStorage.setItem('test', "{key: 'value'}");
 
-    expect(() =>
-      renderHook(() => useLocalStorage({ key: 'test' }))
-    ).toThrowError();
+    expect(() => {
+      return renderHook(() => useLocalStorage({ key: 'test' }));
+    }).toThrowError();
   });
 
   it('should throw an error when setting an item in localStorage fails', async () => {

--- a/packages/react/src/utils/customEventHandler.ts
+++ b/packages/react/src/utils/customEventHandler.ts
@@ -1,0 +1,37 @@
+const CUSTOM_EVENT_KEYS = {
+  localStorage: 'local-storage',
+  sessionStorage: 'session-storage',
+} as const;
+
+const customEventHandler = {
+  localStorage: {
+    key: CUSTOM_EVENT_KEYS['localStorage'],
+    subscribe: (callback: () => void) => {
+      window.addEventListener(CUSTOM_EVENT_KEYS['localStorage'], callback);
+    },
+    unsubscribe: (callback: () => void) => {
+      window.removeEventListener(CUSTOM_EVENT_KEYS['localStorage'], callback);
+    },
+    dispatchEvent: () => {
+      window.dispatchEvent(new StorageEvent(CUSTOM_EVENT_KEYS['localStorage']));
+    },
+  },
+  sessionStorage: {
+    key: CUSTOM_EVENT_KEYS['sessionStorage'],
+    subscribe: (callback: () => void) => {
+      window.addEventListener(CUSTOM_EVENT_KEYS['sessionStorage'], callback);
+    },
+    unsubscribe: (callback: () => void) => {
+      window.removeEventListener(CUSTOM_EVENT_KEYS['sessionStorage'], callback);
+    },
+    dispatchEvent: () => {
+      window.dispatchEvent(
+        new StorageEvent(CUSTOM_EVENT_KEYS['sessionStorage'])
+      );
+    },
+  },
+};
+
+export const getCustomEventHandler = (key: keyof typeof CUSTOM_EVENT_KEYS) => {
+  return customEventHandler[key];
+};

--- a/packages/utils/src/validator/isFunction/index.ts
+++ b/packages/utils/src/validator/isFunction/index.ts
@@ -1,5 +1,5 @@
 export const isFunction = <T extends (...args: any[]) => any>(
   arg: unknown
 ): arg is T => {
-  return arg instanceof Function;
+  return typeof arg === 'function';
 };


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/179

`React v18`부터 지원하는 **[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)** 을 활용해 로컬 스토리지 내의 특정 `key` 데이터를 구독하고, 구독 중인 데이터에 변화가 있을 시 이를 동기화해주는 커스텀 훅입니다.

로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다.

또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.

## 문서 예제 영상

```tsx
const { state, setState, removeState } = useLocalStorage({
  key: 'test',
  initialValue: 'default',
});
```

https://github.com/modern-agile-team/modern-kit/assets/64779472/86d8dd5a-2dfd-4d4c-9ea1-381747b4685f

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)