### PR TITLE
feat(react): useSessionStorage 신규 훅 추가

### DIFF
--- a/.changeset/wet-hats-taste.md
+++ b/.changeset/wet-hats-taste.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useSessionStorage 신규 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useLocalStorage.mdx
+++ b/docs/docs/react/hooks/useLocalStorage.mdx
@@ -4,9 +4,9 @@ import { useLocalStorage } from '@modern-kit/react';
 
 `React v18`부터 지원하는 **[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)** 을 활용해 로컬 스토리지 내의 특정 `key` 데이터를 구독하고, 구독 중인 데이터에 변화가 있을 시 이를 동기화해주는 커스텀 훅입니다.
 
-로컬스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다. 또한, `서버 사이드 렌더링(SSR)`의 경우 로컬스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
+로컬 스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다. 또한, `서버 사이드 렌더링(SSR)`의 경우 로컬 스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
 
-`setState`는 값 자체를 넘길 수 있으며, 함수도 넘길 수 있습니다. 함수로 활용 시에 인자로 state 값을 가져올 수 있습니다.
+`setState`는 값 자체를 넘길 수 있으며, 함수도 넘길 수 있습니다. 함수로 활용 시에 인자로 state를 가져올 수 있습니다.
 
 ```ts
 const { state, setState, removeState } = useLocalStorage<number[]>({
@@ -100,13 +100,13 @@ const Example = () => {
       <p>개발자 도구에서 로컬 스토리지를 확인해보세요!</p>
       <p>state: {state}</p>
       <button onClick={() => setState('foo')}>
-        {`로컬스토리지 "test"key에 "foo"데이터 저장`}
+        {`로컬 스토리지 "test"key에 "foo"데이터 저장`}
       </button>
       <button onClick={() => setState('bar')}>
-        {`로컬스토리지 "test"key에 "bar"데이터 저장`}
+        {`로컬 스토리지 "test"key에 "bar"데이터 저장`}
       </button>
       <button onClick={() => removeState()}>
-        {`로컬스토리지 "test"key 제거`}
+        {`로컬 스토리지 "test"key 제거`}
       </button>
     </div>
   );
@@ -126,13 +126,13 @@ export const Example = () => {
       <p>개발자 도구에서 로컬 스토리지를 확인해보세요!</p>
       <p>state: {state}</p>
       <button onClick={() => setState('foo')}>
-        {`로컬스토리지 "test"key에 "foo"데이터 저장`}
+        {`로컬 스토리지 "test"key에 "foo"데이터 저장`}
       </button>
       <button onClick={() => setState('bar')}>
-        {`로컬스토리지 "test"key에 "bar"데이터 저장`}
+        {`로컬 스토리지 "test"key에 "bar"데이터 저장`}
       </button>
       <button onClick={() => removeState()}>
-        {`로컬스토리지 "test"key 제거`}
+        {`로컬 스토리지 "test"key 제거`}
       </button>
     </div>
   );

--- a/docs/docs/react/hooks/useSessionStorage.mdx
+++ b/docs/docs/react/hooks/useSessionStorage.mdx
@@ -1,0 +1,142 @@
+import { useSessionStorage } from '@modern-kit/react';
+
+# useSessionStorage
+
+`React v18`부터 지원하는 **[useSyncExternalStore](https://react.dev/reference/react/useSyncExternalStore)** 을 활용해 세션 스토리지 내의 특정 `key` 데이터를 구독하고, 구독 중인 데이터에 변화가 있을 시 이를 동기화해주는 커스텀 훅입니다.
+
+세션 스토리지에 구독하고자 하는 `key`가 없을 경우 반환할 `initialValue`로 초기값을 설정할 수 있습니다. 또한, `서버 사이드 렌더링(SSR)`의 경우 세션 스토리지가 동작하지 않기 때문에 `initialValue`가 반환됩니다.
+
+`setState`는 값 자체를 넘길 수 있으며, 함수도 넘길 수 있습니다. 함수로 활용 시에 인자로 state를 가져올 수 있습니다.
+
+```ts
+const { state, setState, removeState } = useSessionStorage<number[]>({
+  key: 'test',
+  initialValue: [1, 2],
+});
+
+setState([1, 2, 3]);
+setState(state => [...state, 3]);
+```
+
+<br />
+
+initialValue를 넘겨주면 더욱 `명확한 타입 추론`이 가능합니다.
+
+```ts
+const { state, setState } = useSessionStorage<number[]>({
+  key: 'test',
+});
+
+state; // number[] | null
+setState(state => {
+  state; // number[] | null
+});
+```
+
+```ts
+const { state, setState } = useSessionStorage<number[]>({
+  key: 'test',
+  initialValue: [],
+});
+
+state; // number[]
+setState(state => {
+  state; // number[]
+});
+```
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useSessionStorage/index.ts)
+
+## Interface
+```ts title="typescript"
+interface UseSessionStorageWithoutInitialValueProps {
+  key: string;
+}
+
+interface UseSessionStorageWithInitialValueProps<T> {
+  key: string;
+  initialValue: T | (() => T);
+}
+
+type UseSessionStorageProps<T> =
+  | UseSessionStorageWithoutInitialValueProps
+  | UseSessionStorageWithInitialValueProps<T>;
+```
+```ts
+// 함수 오버로딩
+export function useSessionStorage<T>({
+  key,
+  initialValue,
+}: UseSessionStorageWithInitialValueProps<T>): {
+  readonly state: T;
+  readonly setState: (value: T | ((state: T) => T)) => void;
+  readonly removeState: () => void;
+};
+
+export function useSessionStorage<T = unknown>({
+  key,
+}: UseSessionStorageWithoutInitialValueProps): {
+  readonly state: T | null;
+  readonly setState: (value: T | ((state: T | null) => T)) => void;
+  readonly removeState: () => void;
+};
+```
+
+## Usage
+```tsx title="typescript"
+import { useSessionStorage } from '@modern-kit/react';
+
+const Example = () => {
+  const { state, setState, removeState } = useSessionStorage<string>({
+    key: 'test',
+    initialValue: 'default',
+  });
+
+  return (
+    <div>
+      <p>개발자 도구에서 세션 스토리지를 확인해보세요!</p>
+      <p>state: {state}</p>
+      <button onClick={() => setState('foo')}>
+        {`세션 스토리지 "test"key에 "foo"데이터 저장`}
+      </button>
+      <button onClick={() => setState('bar')}>
+        {`세션 스토리지 "test"key에 "bar"데이터 저장`}
+      </button>
+      <button onClick={() => removeState()}>
+        {`세션 스토리지 "test"key 제거`}
+      </button>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const { state, setState, removeState } = useSessionStorage({
+    key: 'test',
+    initialValue: 'default',
+  });
+
+  return (
+    <div>
+      <p>개발자 도구에서 세션 스토리지를 확인해보세요!</p>
+      <p>state: {state}</p>
+      <button onClick={() => setState('foo')}>
+        {`세션 스토리지 "test"key에 "foo"데이터 저장`}
+      </button>
+      <button onClick={() => setState('bar')}>
+        {`세션 스토리지 "test"key에 "bar"데이터 저장`}
+      </button>
+      <button onClick={() => removeState()}>
+        {`세션 스토리지 "test"key 제거`}
+      </button>
+    </div>
+  );
+};
+
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -24,6 +24,7 @@ export * from './usePreservedState';
 export * from './usePrevious';
 export * from './useResizeObserver';
 export * from './useScrollLock';
+export * from './useSessionStorage';
 export * from './useTimeout';
 export * from './useToggle';
 export * from './useUnMount';

--- a/packages/react/src/hooks/useSessionStorage/index.ts
+++ b/packages/react/src/hooks/useSessionStorage/index.ts
@@ -1,0 +1,106 @@
+import { isFunction, parseJSON } from '@modern-kit/utils';
+import { useCallback, useMemo, useSyncExternalStore } from 'react';
+import { getCustomEventHandler } from '../../utils/customEventHandler';
+
+interface UseSessionStorageWithoutInitialValueProps {
+  key: string;
+}
+
+interface UseSessionStorageWithInitialValueProps<T> {
+  key: string;
+  initialValue: T | (() => T);
+}
+
+type UseSessionStorageProps<T> =
+  | UseSessionStorageWithoutInitialValueProps
+  | UseSessionStorageWithInitialValueProps<T>;
+
+const sessionStorageEventHandler = getCustomEventHandler('sessionStorage');
+
+const subscribe = (callback: () => void) => {
+  sessionStorageEventHandler.subscribe(callback);
+  return () => {
+    sessionStorageEventHandler.unsubscribe(callback);
+  };
+};
+
+const getSnapshot = (key: string) => {
+  return window.sessionStorage.getItem(key);
+};
+
+// SSR 환경에서 initialValue를 반환
+const getServerSnapshot = <T>(initialValue: T | null) => {
+  return JSON.stringify(initialValue);
+};
+
+// 함수 오버로딩
+export function useSessionStorage<T>({
+  key,
+  initialValue,
+}: UseSessionStorageWithInitialValueProps<T>): {
+  readonly state: T;
+  readonly setState: (value: T | ((state: T) => T)) => void;
+  readonly removeState: () => void;
+};
+
+export function useSessionStorage<T = unknown>({
+  key,
+}: UseSessionStorageWithoutInitialValueProps): {
+  readonly state: T | null;
+  readonly setState: (value: T | ((state: T | null) => T)) => void;
+  readonly removeState: () => void;
+};
+
+export function useSessionStorage<T>(props: UseSessionStorageProps<T>) {
+  const { key } = props;
+  const initialValue = 'initialValue' in props ? props.initialValue : null;
+
+  const initialValueToUse = useMemo(() => {
+    return isFunction(initialValue) ? initialValue() : initialValue;
+  }, [initialValue]);
+
+  const externalStoreState = useSyncExternalStore(
+    subscribe,
+    () => getSnapshot(key),
+    () => getServerSnapshot(initialValueToUse)
+  );
+
+  const state = useMemo(() => {
+    return externalStoreState
+      ? parseJSON<T>(externalStoreState)
+      : initialValueToUse;
+  }, [externalStoreState, initialValueToUse]);
+
+  const setState = useCallback(
+    (value: T | ((state: T | null) => T)) => {
+      try {
+        const prevStateString = getSnapshot(key);
+        const prevState = prevStateString
+          ? parseJSON<T>(prevStateString)
+          : initialValueToUse;
+        const valueToUse = isFunction(value) ? value(prevState) : value;
+
+        window.sessionStorage.setItem(key, JSON.stringify(valueToUse));
+        sessionStorageEventHandler.dispatchEvent();
+      } catch (err) {
+        throw new Error(
+          `Failed to store data for key "${key}" in sessionStorage: ${err}`
+        );
+      }
+    },
+    [key, initialValueToUse]
+  );
+
+  const removeState = useCallback(() => {
+    try {
+      window.sessionStorage.removeItem(key);
+      sessionStorageEventHandler.dispatchEvent();
+    } catch (err) {
+      throw new Error(
+        `Failed to remove key "${key}" from sessionStorage: ${err}`
+      );
+    }
+  }, [key]);
+
+  return { state, setState, removeState } as const;
+}

--- a/packages/react/src/hooks/useSessionStorage/index.ts
+++ b/packages/react/src/hooks/useSessionStorage/index.ts
@@ -33,7 +33,6 @@ const getServerSnapshot = <T>(initialValue: T | null) => {
   return JSON.stringify(initialValue);
 };
 
-// 함수 오버로딩
 export function useSessionStorage<T>({
   key,
   initialValue,

--- a/packages/react/src/hooks/useSessionStorage/useSessionStorage.spec.tsx
+++ b/packages/react/src/hooks/useSessionStorage/useSessionStorage.spec.tsx
@@ -1,0 +1,129 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useSessionStorage } from '.';
+import { renderToString } from 'react-dom/server';
+
+afterEach(() => {
+  sessionStorage.clear();
+});
+
+describe('useSessionStorage', () => {
+  it('should initialize with the default value if no value is in sessionStorage', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    expect(result.current.state).toBe('default');
+  });
+
+  it('should initialize with the default function return value if no value is in sessionStorage', () => {
+    const { result } = renderHook(() =>
+      useSessionStorage({ key: 'test', initialValue: () => 'default' })
+    );
+
+    expect(result.current.state).toBe('default');
+  });
+
+  it('should initialize with the value from sessionStorage', () => {
+    sessionStorage.setItem('test', JSON.stringify('storedValue'));
+
+    const { result } = renderHook(() =>
+      useSessionStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    expect(result.current.state).toBe('storedValue');
+  });
+
+  it('should update sessionStorage when state changes(1)', async () => {
+    const { result } = renderHook(() =>
+      useSessionStorage({ key: 'test', initialValue: 'default' })
+    );
+
+    await waitFor(() => {
+      result.current.setState('newValue');
+    });
+
+    expect(result.current.state).toBe('newValue');
+    expect(sessionStorage.getItem('test')).toBe(JSON.stringify('newValue'));
+  });
+
+  it('should update sessionStorage when state changes(2)', async () => {
+    sessionStorage.setItem('test', JSON.stringify([1, 2, 3]));
+
+    const { result } = renderHook(() =>
+      useSessionStorage({ key: 'test', initialValue: [1, 2, 3] })
+    );
+
+    await waitFor(() => {
+      result.current.setState((state) => [...state, 4]);
+    });
+
+    expect(result.current.state).toEqual([1, 2, 3, 4]);
+    expect(sessionStorage.getItem('test')).toBe(JSON.stringify([1, 2, 3, 4]));
+  });
+
+  it('should remove the value from sessionStorage', async () => {
+    sessionStorage.setItem('test', JSON.stringify('storedValue'));
+
+    const { result } = renderHook(() =>
+      useSessionStorage<string>({ key: 'test' })
+    );
+
+    await waitFor(() => {
+      result.current.removeState();
+    });
+
+    expect(result.current.state).toBeNull();
+    expect(sessionStorage.getItem('test')).toBeNull();
+  });
+
+  it('should render initial value during server-side rendering', async () => {
+    const TestComponent = () => {
+      const { state } = useSessionStorage({ key: 'test', initialValue: 'ssr' });
+      return <p>{state}</p>;
+    };
+
+    const html = renderToString(<TestComponent />); // server side rendering
+
+    expect(html).toContain('ssr');
+  });
+
+  it('should infer the type based on the presence of initialValue', () => {
+    const { result: result1 } = renderHook(() =>
+      useSessionStorage<string>({ key: 'test' })
+    );
+    expectTypeOf(result1.current.state).toEqualTypeOf<string | null>();
+
+    const { result: result2 } = renderHook(() =>
+      useSessionStorage<string>({ key: 'test', initialValue: 'default' })
+    );
+    expectTypeOf(result2.current.state).toEqualTypeOf<string>();
+  });
+
+  it('should throw an error when sessionStorage contains invalid JSON', async () => {
+    sessionStorage.setItem('test', "{key: 'value'}");
+
+    expect(() => {
+      return renderHook(() => useSessionStorage({ key: 'test' }));
+    }).toThrowError();
+  });
+
+  it('should throw an error when setting an item in sessionStorage fails', async () => {
+    const { result } = renderHook(() => useSessionStorage({ key: 'test' }));
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error();
+    });
+
+    expect(() => result.current.setState('error')).toThrowError();
+  });
+
+  it('should throw an error when removing an item from sessionStorage fails', async () => {
+    const { result } = renderHook(() => useSessionStorage({ key: 'test' }));
+
+    vi.spyOn(Storage.prototype, 'removeItem').mockImplementation(() => {
+      throw new Error();
+    });
+
+    expect(() => result.current.removeState()).toThrowError();
+  });
+});


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/240
localStorage: https://github.com/modern-agile-team/modern-kit/pull/239

useLocalStorage와 유사하지만 localStorage가 아닌 sessionStorage를 활용하는 커스텀 훅입니다.


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)