### PR TITLE
feat(react): useIntersectionObserver enabled 옵션 추가

### DIFF
--- a/.changeset/violet-moons-glow.md
+++ b/.changeset/violet-moons-glow.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+feat(react): useIntersectionObserver enabled 옵션 추가 - @ssi02014

--- a/docs/docs/react/hooks/useIntersectionObserver.mdx
+++ b/docs/docs/react/hooks/useIntersectionObserver.mdx
@@ -6,6 +6,8 @@ import { useIntersectionObserver } from '@modern-kit/react';
 
 `calledOnce`옵션을 `true`로 설정하면 `onIntersectStart`와 `onIntersectEnd`를 각각 한번씩 호출 할 수 있습니다.
 
+`enabled`옵션을 통해 `onIntersect*` 콜백 함수들의 호출을 제어 할 수 있습니다. `false`라면 타겟 엘리먼트가 Viewport에 노출하더라도 실행되지 않습니다.
+
 Intersection Observer Option을 설정할 수 있습니다.(하단 `Note` 참고)
 
 <br />
@@ -25,11 +27,14 @@ interface UseIntersectionObserverProps extends IntersectionObserverInit {
   onIntersectStart?: (entry: IntersectionObserverEntry) => void;
   onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
   calledOnce?: boolean;
+  enabled?: boolean;
 }
-
+```
+```ts title="typescript"
 const useIntersectionObserver: <T extends HTMLElement>({
   onIntersectStart,
   onIntersectEnd,
+  enabled, // default: true
   calledOnce, // default: false
   root, // default: null
   threshold, // default: 0
@@ -51,7 +56,6 @@ const Example = () => {
     onIntersectEnd: (entry) => {
       console.log("onIntersectEnd: ", entry);
     },
-    calledOnce: false
   });
   
   const boxStyle = {
@@ -82,7 +86,6 @@ export const Example = () => {
     onIntersectEnd: (entry) => {
       console.log("onIntersectEnd: ", entry);
     },
-    calledOnce: false
   });
   const boxStyle = {
     height: "800px", 

--- a/packages/react/src/hooks/useIntersectionObserver/index.ts
+++ b/packages/react/src/hooks/useIntersectionObserver/index.ts
@@ -10,6 +10,17 @@ export interface UseIntersectionObserverProps extends IntersectionObserverInit {
   enabled?: boolean;
 }
 
+const useIntersectionObserver: <T extends HTMLElement>({
+  onIntersectStart,
+  onIntersectEnd,
+  enabled,
+  calledOnce,
+  root,
+  threshold,
+  rootMargin,
+}: UseIntersectionObserverProps) => {
+  ref: (node: T) => void;
+};
 export const useIntersectionObserver = <T extends HTMLElement>({
   onIntersectStart = noop,
   onIntersectEnd = noop,

--- a/packages/react/src/hooks/useIntersectionObserver/index.ts
+++ b/packages/react/src/hooks/useIntersectionObserver/index.ts
@@ -7,11 +7,13 @@ export interface UseIntersectionObserverProps extends IntersectionObserverInit {
   onIntersectStart?: (entry: IntersectionObserverEntry) => void;
   onIntersectEnd?: (entry: IntersectionObserverEntry) => void;
   calledOnce?: boolean;
+  enabled?: boolean;
 }
 
 export const useIntersectionObserver = <T extends HTMLElement>({
   onIntersectStart = noop,
   onIntersectEnd = noop,
+  enabled = true,
   calledOnce = false,
   root = null,
   threshold = 0,
@@ -23,7 +25,7 @@ export const useIntersectionObserver = <T extends HTMLElement>({
 
   const intersectionObserverCallback = usePreservedCallback(
     ([entry]: IntersectionObserverEntry[], observer: IntersectionObserver) => {
-      if (!entry) return;
+      if (!enabled || !entry) return;
 
       const targetElement = entry.target as T;
 

--- a/packages/react/src/hooks/useIntersectionObserver/index.ts
+++ b/packages/react/src/hooks/useIntersectionObserver/index.ts
@@ -10,17 +10,6 @@ export interface UseIntersectionObserverProps extends IntersectionObserverInit {
   enabled?: boolean;
 }
 
-const useIntersectionObserver: <T extends HTMLElement>({
-  onIntersectStart,
-  onIntersectEnd,
-  enabled,
-  calledOnce,
-  root,
-  threshold,
-  rootMargin,
-}: UseIntersectionObserverProps) => {
-  ref: (node: T) => void;
-};
 export const useIntersectionObserver = <T extends HTMLElement>({
   onIntersectStart = noop,
   onIntersectEnd = noop,

--- a/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
+++ b/packages/react/src/hooks/useIntersectionObserver/useIntersectionObserver.spec.tsx
@@ -19,17 +19,20 @@ interface TestComponentProps {
   onIntersectStart: () => void;
   onIntersectEnd: () => void;
   calledOnce?: boolean;
+  enabled?: boolean;
 }
 
 const TestComponent = ({
   onIntersectStart,
   onIntersectEnd,
   calledOnce,
+  enabled,
 }: TestComponentProps) => {
   const { ref: boxRef } = useIntersectionObserver<HTMLDivElement>({
     onIntersectStart,
     onIntersectEnd,
     calledOnce,
+    enabled,
   });
 
   return <div ref={boxRef}>box</div>;
@@ -81,6 +84,41 @@ describe('useIntersectionObserver', () => {
     await waitFor(() => mockIntersecting({ type: 'view', element: box }));
 
     expect(intersectStartMock).toBeCalledTimes(1);
+    expect(intersectEndMock).toBeCalledTimes(1);
+  });
+
+  it('should not call the action callback functions when the enabled option is false', async () => {
+    const { rerender } = renderSetup(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+        enabled={false}
+      />
+    );
+
+    const box = screen.getByText('box');
+
+    expect(intersectStartMock).toBeCalledTimes(0);
+    expect(intersectEndMock).toBeCalledTimes(0);
+
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    expect(intersectStartMock).toBeCalledTimes(0);
+
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
+    expect(intersectEndMock).toBeCalledTimes(0);
+
+    rerender(
+      <TestComponent
+        onIntersectStart={intersectStartMock}
+        onIntersectEnd={intersectEndMock}
+        enabled={true}
+      />
+    );
+
+    await waitFor(() => mockIntersecting({ type: 'view', element: box }));
+    expect(intersectStartMock).toBeCalledTimes(1);
+
+    await waitFor(() => mockIntersecting({ type: 'hide', element: box }));
     expect(intersectEndMock).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Overview

useIntersectionObserver enabled 옵션 추가

`enabled`옵션을 통해 `onIntersect*` 콜백 함수들의 호출을 제어 할 수 있습니다. `false`라면 타겟 엘리먼트가 Viewport에 노출하더라도 실행되지 않습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)