### PR TITLE
feat(react): useStep 훅 추가

### DIFF
--- a/.changeset/forty-bugs-do.md
+++ b/.changeset/forty-bugs-do.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useStep 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -2,7 +2,7 @@ import { useStep } from '@modern-kit/react';
 
 # useStep
 
-mult-step process의 step을 관리하고 추적해주는 커스텀 훅입니다.
+`mult-step process`의 `step`을 관리하고 추적해주는 커스텀 훅입니다.
 
 <br />
 
@@ -14,6 +14,7 @@ mult-step process의 step을 관리하고 추적해주는 커스텀 훅입니다
 interface UseStepProps {
   maxStep: number;
   initialStep?: number; // default: 1
+  infinite?: boolean; // default: false
 }
 
 type StepAction = ({
@@ -25,15 +26,18 @@ type StepAction = ({
 }) => void;
 ```
 ```ts title="typescript"
-const useStep: ({ maxStep, initialStep }: UseStepProps) => {
+const useStep: ({ maxStep, initialStep, infinite }: UseStepProps) => {
   readonly currentStep: number; // 현재 Step
   readonly hasNextStep: boolean; // 다음 Step 이동 가능 여부
   readonly hasPrevStep: boolean; // 이전 Step 이동 가능 여부
-  readonly setStep: (step: number | ((step: number) => number), action?: StepAction) => void; // 특정 Step 이동 함수
+  readonly setStep: (
+    step: number | ((step: number) => number),
+    action?: StepAction
+  ) => void; // 특정 Step 이동 함수
   readonly nextStep: (action?: StepAction) => void; // 다음 Step 이동 함수
   readonly prevStep: (action?: StepAction) => void; // 이전 Step 이동 함수
   readonly resetStep: (action?: StepAction) => void; // initialValue 이동 함수
-}
+};
 ```
 
 ## Usage

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -1,0 +1,207 @@
+import { useStep } from '@modern-kit/react';
+
+# useStep
+
+mult-step process의 step을 관리하고 추적해주는 커스텀 훅입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useStep/index.ts)
+
+## Interface
+```ts title="typescript"
+interface UseStepProps {
+  maxStep: number;
+  initialStep?: number; // default: 1
+}
+
+type StepAction = ({
+  prevStep,
+  nextStep,
+}: {
+  prevStep: number;
+  nextStep: number;
+}) => void;
+```
+```ts title="typescript"
+const useStep: ({ maxStep, initialStep }: UseStepProps) => {
+  readonly currentStep: number;
+  readonly hasNextStep: boolean;
+  readonly hasPrevStep: boolean;
+  readonly setStep: (step: number | ((step: number) => number), action?: StepAction) => void;
+  readonly nextStep: (action?: StepAction) => void;
+  readonly prevStep: (action?: StepAction) => void;
+  readonly resetStep: (action?: StepAction) => void;
+}
+```
+
+## Usage
+```ts title="typescript"
+import { useStep } from '@modern-kit/react';
+
+export const Example = () => {
+  const {
+    currentStep,
+    hasNextStep,
+    hasPrevStep,
+    setStep,
+    nextStep,
+    prevStep,
+    resetStep,
+  } = useStep({ maxStep: 4 });
+
+  const handleNextStep = () => {
+    nextStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handlePrevStep = () => {
+    prevStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handleSetStep = () => {
+    setStep(3, ({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handleresetStep = () => {
+    resetStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const boxStyle = {
+    width: '300px',
+    height: '120px',
+    fontSize: '21px',
+  };
+
+  return (
+    <div>
+      <div>
+        <button onClick={handlePrevStep}>이전 스탭</button>
+        <button onClick={handleNextStep}>다음 스탭</button>
+        <button onClick={handleSetStep}>3스탭으로 이동</button>
+        <button onClick={handleresetStep}>초기화 스탭</button>
+      </div>
+      <div>
+        <p>currentStep: {currentStep}</p>
+        <p>hasNextStep: {`${hasNextStep}`}</p>
+        <p>hasPrevStep: {`${hasPrevStep}`}</p>
+      </div>
+      <div>
+        {currentStep === 1 && (
+          <div style={{ ...boxStyle, backgroundColor: 'red' }}>
+            1번 Step Box
+          </div>
+        )}
+        {currentStep === 2 && (
+          <div style={{ ...boxStyle, backgroundColor: 'green' }}>
+            2번 Step Box
+          </div>
+        )}
+        {currentStep === 3 && (
+          <div style={{ ...boxStyle, backgroundColor: 'blue' }}>
+            3번 Step Box
+          </div>
+        )}
+        {currentStep === 4 && (
+          <div style={{ ...boxStyle, backgroundColor: 'yellow' }}>
+            4번 Step Box
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const {
+    currentStep,
+    hasNextStep,
+    hasPrevStep,
+    setStep,
+    nextStep,
+    prevStep,
+    resetStep,
+  } = useStep({ maxStep: 4 });
+
+  const handleNextStep = () => {
+    nextStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handlePrevStep = () => {
+    prevStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handleSetStep = () => {
+    setStep(3, ({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const handleresetStep = () => {
+    resetStep(({ prevStep, nextStep }) => {
+      console.log(`${prevStep}에서 ${nextStep}로 이동`);
+    });
+  };
+
+  const boxStyle = {
+    width: '300px',
+    height: '120px',
+    fontSize: '21px',
+  };
+
+  return (
+    <div>
+      <div>
+        <button onClick={handlePrevStep}>이전 스탭</button>
+        <button onClick={handleNextStep}>다음 스탭</button>
+        <button onClick={handleSetStep}>3스탭으로 이동</button>
+        <button onClick={handleresetStep}>초기화 스탭</button>
+      </div>
+      <div>
+        <p>currentStep: {currentStep}</p>
+        <p>hasNextStep: {`${hasNextStep}`}</p>
+        <p>hasPrevStep: {`${hasPrevStep}`}</p>
+      </div>
+      <div>
+        {currentStep === 1 && (
+          <div style={{ ...boxStyle, backgroundColor: 'red' }}>
+            1번 Step Box
+          </div>
+        )}
+        {currentStep === 2 && (
+          <div style={{ ...boxStyle, backgroundColor: 'green' }}>
+            2번 Step Box
+          </div>
+        )}
+        {currentStep === 3 && (
+          <div style={{ ...boxStyle, backgroundColor: 'blue' }}>
+            3번 Step Box
+          </div>
+        )}
+        {currentStep === 4 && (
+          <div style={{ ...boxStyle, backgroundColor: 'yellow' }}>
+            4번 Step Box
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+
+<Example />

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -1,4 +1,5 @@
 import { useStep } from '@modern-kit/react';
+import { useState } from 'react';
 
 # useStep
 
@@ -45,6 +46,7 @@ const useStep: ({ maxStep, initialStep, infinite }: UseStepProps) => {
 import { useStep } from '@modern-kit/react';
 
 export const Example = () => {
+  const [infinite, setInfinite] = useState(true);
   const {
     currentStep,
     hasNextStep,
@@ -53,7 +55,7 @@ export const Example = () => {
     nextStep,
     prevStep,
     resetStep,
-  } = useStep({ maxStep: 4 });
+  } = useStep({ maxStep: 4, infinite: infinite });
 
   const handleNextStep = () => {
     nextStep(({ prevStep, nextStep }) => {
@@ -92,11 +94,13 @@ export const Example = () => {
         <button onClick={handleNextStep}>다음 스탭</button>
         <button onClick={handleSetStep}>3스탭으로 이동</button>
         <button onClick={handleresetStep}>초기화 스탭</button>
+        <button onClick={() => setInfinite(!infinite)}>infinite 토글</button>
       </div>
       <div>
         <p>currentStep: {currentStep}</p>
         <p>hasNextStep: {`${hasNextStep}`}</p>
         <p>hasPrevStep: {`${hasPrevStep}`}</p>
+        <p>infinite: {`${infinite}`}</p>
       </div>
       <div>
         {currentStep === 1 && (
@@ -128,6 +132,7 @@ export const Example = () => {
 ## Example
 
 export const Example = () => {
+  const [infinite, setInfinite] = useState(false);
   const {
     currentStep,
     hasNextStep,
@@ -136,7 +141,7 @@ export const Example = () => {
     nextStep,
     prevStep,
     resetStep,
-  } = useStep({ maxStep: 4 });
+  } = useStep({ maxStep: 4, infinite: infinite });
 
   const handleNextStep = () => {
     nextStep(({ prevStep, nextStep }) => {
@@ -175,11 +180,13 @@ export const Example = () => {
         <button onClick={handleNextStep}>다음 스탭</button>
         <button onClick={handleSetStep}>3스탭으로 이동</button>
         <button onClick={handleresetStep}>초기화 스탭</button>
+        <button onClick={() => setInfinite(!infinite)}>infinite 토글</button>
       </div>
       <div>
         <p>currentStep: {currentStep}</p>
         <p>hasNextStep: {`${hasNextStep}`}</p>
         <p>hasPrevStep: {`${hasPrevStep}`}</p>
+        <p>infinite: {`${infinite}`}</p>
       </div>
       <div>
         {currentStep === 1 && (

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -42,7 +42,7 @@ const useStep: ({ maxStep, initialStep, infinite }: UseStepProps) => {
 ```
 
 ## Usage
-```ts title="typescript"
+```tsx title="typescript"
 import { useStep } from '@modern-kit/react';
 
 export const Example = () => {

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -26,13 +26,13 @@ type StepAction = ({
 ```
 ```ts title="typescript"
 const useStep: ({ maxStep, initialStep }: UseStepProps) => {
-  readonly currentStep: number;
-  readonly hasNextStep: boolean;
-  readonly hasPrevStep: boolean;
-  readonly setStep: (step: number | ((step: number) => number), action?: StepAction) => void;
-  readonly nextStep: (action?: StepAction) => void;
-  readonly prevStep: (action?: StepAction) => void;
-  readonly resetStep: (action?: StepAction) => void;
+  readonly currentStep: number; // 현재 Step
+  readonly hasNextStep: boolean; // 다음 Step 이동 가능 여부
+  readonly hasPrevStep: boolean; // 이전 Step 이동 가능 여부
+  readonly setStep: (step: number | ((step: number) => number), action?: StepAction) => void; // 특정 Step 이동 함수
+  readonly nextStep: (action?: StepAction) => void; // 다음 Step 이동 함수
+  readonly prevStep: (action?: StepAction) => void; // 이전 Step 이동 함수
+  readonly resetStep: (action?: StepAction) => void; // initialValue 이동 함수
 }
 ```
 

--- a/docs/docs/react/hooks/useStep.mdx
+++ b/docs/docs/react/hooks/useStep.mdx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 
 # useStep
 
-`mult-step process`의 `step`을 관리하고 추적해주는 커스텀 훅입니다.
+`multi-step process`의 `step`을 관리하고 추적해주는 커스텀 훅입니다.
 
 <br />
 
@@ -35,8 +35,8 @@ const useStep: ({ maxStep, initialStep, infinite }: UseStepProps) => {
     step: number | ((step: number) => number),
     action?: StepAction
   ) => void; // 특정 Step 이동 함수
-  readonly nextStep: (action?: StepAction) => void; // 다음 Step 이동 함수
-  readonly prevStep: (action?: StepAction) => void; // 이전 Step 이동 함수
+  readonly goToNextStep: (action?: StepAction) => void; // 다음 Step 이동 함수
+  readonly goToPrevStep: (action?: StepAction) => void; // 이전 Step 이동 함수
   readonly resetStep: (action?: StepAction) => void; // initialValue 이동 함수
 };
 ```
@@ -57,14 +57,14 @@ export const Example = () => {
     resetStep,
   } = useStep({ maxStep: 4, infinite: infinite });
 
-  const handleNextStep = () => {
-    nextStep(({ prevStep, nextStep }) => {
+  const handleGoToNextStep = () => {
+    goToNextStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
   };
 
-  const handlePrevStep = () => {
-    prevStep(({ prevStep, nextStep }) => {
+  const handleGoToPrevStep = () => {
+    goToPrevStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
   };
@@ -75,7 +75,7 @@ export const Example = () => {
     });
   };
 
-  const handleresetStep = () => {
+  const handleResetStep = () => {
     resetStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
@@ -90,10 +90,10 @@ export const Example = () => {
   return (
     <div>
       <div>
-        <button onClick={handlePrevStep}>이전 스탭</button>
-        <button onClick={handleNextStep}>다음 스탭</button>
+        <button onClick={handleGoToPrevStep}>이전 스탭</button>
+        <button onClick={handleGoToNextStep}>다음 스탭</button>
         <button onClick={handleSetStep}>3스탭으로 이동</button>
-        <button onClick={handleresetStep}>초기화 스탭</button>
+        <button onClick={handleResetStep}>초기화 스탭</button>
         <button onClick={() => setInfinite(!infinite)}>infinite 토글</button>
       </div>
       <div>
@@ -143,13 +143,13 @@ export const Example = () => {
     resetStep,
   } = useStep({ maxStep: 4, infinite: infinite });
 
-  const handleNextStep = () => {
+  const handleGoToNextStep = () => {
     nextStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
   };
 
-  const handlePrevStep = () => {
+  const handleGoToPrevStep = () => {
     prevStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
@@ -161,7 +161,7 @@ export const Example = () => {
     });
   };
 
-  const handleresetStep = () => {
+  const handleResetStep = () => {
     resetStep(({ prevStep, nextStep }) => {
       console.log(`${prevStep}에서 ${nextStep}로 이동`);
     });
@@ -176,10 +176,10 @@ export const Example = () => {
   return (
     <div>
       <div>
-        <button onClick={handlePrevStep}>이전 스탭</button>
-        <button onClick={handleNextStep}>다음 스탭</button>
+        <button onClick={handleGoToPrevStep}>이전 스탭</button>
+        <button onClick={handleGoToNextStep}>다음 스탭</button>
         <button onClick={handleSetStep}>3스탭으로 이동</button>
-        <button onClick={handleresetStep}>초기화 스탭</button>
+        <button onClick={handleResetStep}>초기화 스탭</button>
         <button onClick={() => setInfinite(!infinite)}>infinite 토글</button>
       </div>
       <div>

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -25,6 +25,7 @@ export * from './usePrevious';
 export * from './useResizeObserver';
 export * from './useScrollLock';
 export * from './useSessionStorage';
+export * from './useStep';
 export * from './useTimeout';
 export * from './useToggle';
 export * from './useUnMount';

--- a/packages/react/src/hooks/useStep/index.ts
+++ b/packages/react/src/hooks/useStep/index.ts
@@ -1,0 +1,74 @@
+import { useCallback, useState } from 'react';
+import { isFunction } from '@modern-kit/utils';
+
+interface UseStepProps {
+  maxStep: number;
+  initialStep?: number;
+}
+
+type StepAction = ({
+  prevStep,
+  nextStep,
+}: {
+  prevStep: number;
+  nextStep: number;
+}) => void;
+
+export const useStep = ({ maxStep, initialStep = 1 }: UseStepProps) => {
+  const [currentStep, setCurrentStep] = useState(initialStep);
+  const hasNextStep = currentStep < maxStep;
+  const hasPrevStep = currentStep > 1;
+
+  const setStep = useCallback(
+    (step: number | ((step: number) => number), action?: StepAction) => {
+      const nextStep = isFunction(step) ? step(currentStep) : step;
+      const isValidNextStep = nextStep >= 1 && nextStep <= maxStep;
+
+      if (isValidNextStep) {
+        if (action) action({ prevStep: currentStep, nextStep: nextStep });
+        setCurrentStep(step);
+        return;
+      }
+      throw new Error('Step not valid');
+    },
+    [currentStep, maxStep]
+  );
+
+  const nextStep = useCallback(
+    (action?: StepAction) => {
+      if (!hasNextStep) return;
+
+      if (action) action({ prevStep: currentStep, nextStep: currentStep + 1 });
+      setCurrentStep((step) => step + 1);
+    },
+    [currentStep, hasNextStep]
+  );
+
+  const prevStep = useCallback(
+    (action?: StepAction) => {
+      if (!hasPrevStep) return;
+
+      if (action) action({ prevStep: currentStep, nextStep: currentStep - 1 });
+      setCurrentStep((step) => step - 1);
+    },
+    [currentStep, hasPrevStep]
+  );
+
+  const resetStep = useCallback(
+    (action?: StepAction) => {
+      if (action) action({ prevStep: currentStep, nextStep: initialStep });
+      setCurrentStep(initialStep);
+    },
+    [currentStep, initialStep]
+  );
+
+  return {
+    currentStep,
+    hasNextStep,
+    hasPrevStep,
+    setStep,
+    nextStep,
+    prevStep,
+    resetStep,
+  } as const;
+};

--- a/packages/react/src/hooks/useStep/index.ts
+++ b/packages/react/src/hooks/useStep/index.ts
@@ -81,7 +81,7 @@ export const useStep = ({
     [currentStep, getNextStep]
   );
 
-  const nextStep = useCallback(
+  const goToNextStep = useCallback(
     (action?: StepAction) => {
       if (!hasNextStep) {
         handleStepOverflow('nextStep', action);
@@ -92,7 +92,7 @@ export const useStep = ({
     [hasNextStep, handleStepWithinBounds, handleStepOverflow]
   );
 
-  const prevStep = useCallback(
+  const goToPrevStep = useCallback(
     (action?: StepAction) => {
       if (!hasPrevStep) {
         handleStepOverflow('prevStep', action);
@@ -118,8 +118,8 @@ export const useStep = ({
     hasNextStep,
     hasPrevStep,
     setStep,
-    nextStep,
-    prevStep,
+    goToNextStep,
+    goToPrevStep,
     resetStep,
   } as const;
 };

--- a/packages/react/src/hooks/useStep/useStep.spec.ts
+++ b/packages/react/src/hooks/useStep/useStep.spec.ts
@@ -2,8 +2,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { useStep } from '.';
 
 describe('useStep', () => {
-  const nextStepActionMockFn = vi.fn();
-  const prevStepActionMockFn = vi.fn();
+  const goToNextStepActionMockFn = vi.fn();
+  const goToPrevStepActionMockFn = vi.fn();
   const setStepActionMockFn = vi.fn();
   const resetStepActionMockFn = vi.fn();
 
@@ -17,98 +17,58 @@ describe('useStep', () => {
     expect(result.current.hasPrevStep).toBe(true);
   });
 
-  it('should go to the next step', async () => {
+  it('should go to the next step and call the provided action', async () => {
     const { result } = renderHook(() => useStep({ maxStep: 3 }));
 
     await waitFor(() => {
-      result.current.nextStep();
+      result.current.goToNextStep();
     });
 
     expect(result.current.currentStep).toBe(2);
     expect(result.current.hasNextStep).toBe(true);
 
     await waitFor(() => {
-      result.current.nextStep();
+      result.current.goToNextStep(goToNextStepActionMockFn);
     });
 
     expect(result.current.currentStep).toBe(3);
     expect(result.current.hasNextStep).toBe(false);
+    expect(goToNextStepActionMockFn).toBeCalledTimes(1);
 
     await waitFor(() => {
-      result.current.nextStep();
+      result.current.goToNextStep();
     });
 
     expect(result.current.currentStep).toBe(3);
     expect(result.current.hasNextStep).toBe(false);
   });
 
-  it('should go to the next step and call the provided action', async () => {
-    const { result } = renderHook(() => useStep({ maxStep: 3 }));
-
-    await waitFor(() => {
-      result.current.nextStep(nextStepActionMockFn);
-    });
-
-    expect(result.current.currentStep).toBe(2);
-    expect(nextStepActionMockFn).toBeCalled();
-  });
-
-  it('should go to the previous step', async () => {
+  it('should go to the previous step and call the provided action', async () => {
     const { result } = renderHook(() =>
       useStep({ maxStep: 4, initialStep: 3 })
     );
 
     await waitFor(() => {
-      result.current.prevStep();
+      result.current.goToPrevStep();
     });
 
     expect(result.current.currentStep).toBe(2);
     expect(result.current.hasPrevStep).toBe(true);
 
     await waitFor(() => {
-      result.current.prevStep();
+      result.current.goToPrevStep(goToPrevStepActionMockFn);
     });
 
     expect(result.current.currentStep).toBe(1);
     expect(result.current.hasPrevStep).toBe(false);
+    expect(goToPrevStepActionMockFn).toBeCalledTimes(1);
 
     await waitFor(() => {
-      result.current.prevStep();
+      result.current.goToPrevStep();
     });
 
     expect(result.current.currentStep).toBe(1);
     expect(result.current.hasPrevStep).toBe(false);
-  });
-
-  it('should go to the previous step and call the provided action', async () => {
-    const { result } = renderHook(() =>
-      useStep({ maxStep: 3, initialStep: 2 })
-    );
-
-    await waitFor(() => {
-      result.current.prevStep(prevStepActionMockFn);
-    });
-
-    expect(result.current.currentStep).toBe(1);
-    expect(prevStepActionMockFn).toBeCalled();
-  });
-
-  it('should handle infinite steps', async () => {
-    const { result } = renderHook(() =>
-      useStep({ maxStep: 3, infinite: true })
-    );
-
-    await waitFor(() => {
-      result.current.prevStep();
-    });
-
-    expect(result.current.currentStep).toBe(3);
-
-    await waitFor(() => {
-      result.current.nextStep();
-    });
-
-    expect(result.current.currentStep).toBe(1);
   });
 
   it('should handle infinite steps and call the provided action', async () => {
@@ -117,18 +77,17 @@ describe('useStep', () => {
     );
 
     await waitFor(() => {
-      result.current.prevStep(prevStepActionMockFn);
+      result.current.goToPrevStep();
     });
 
     expect(result.current.currentStep).toBe(3);
-    expect(prevStepActionMockFn).toBeCalledTimes(1);
 
     await waitFor(() => {
-      result.current.nextStep(nextStepActionMockFn);
+      result.current.goToNextStep(goToPrevStepActionMockFn);
     });
 
     expect(result.current.currentStep).toBe(1);
-    expect(nextStepActionMockFn).toBeCalledTimes(1);
+    expect(goToPrevStepActionMockFn).toBeCalledTimes(1);
   });
 
   it('should set the step correctly when a number is provided', async () => {

--- a/packages/react/src/hooks/useStep/useStep.spec.ts
+++ b/packages/react/src/hooks/useStep/useStep.spec.ts
@@ -17,7 +17,7 @@ describe('useStep', () => {
     expect(result.current.hasPrevStep).toBe(true);
   });
 
-  it('should go to the next step and update state correctly', async () => {
+  it('should go to the next step', async () => {
     const { result } = renderHook(() => useStep({ maxStep: 3 }));
 
     await waitFor(() => {
@@ -53,7 +53,7 @@ describe('useStep', () => {
     expect(nextStepActionMockFn).toBeCalled();
   });
 
-  it('should go to the previous step and update state correctly', async () => {
+  it('should go to the previous step', async () => {
     const { result } = renderHook(() =>
       useStep({ maxStep: 4, initialStep: 3 })
     );
@@ -93,6 +93,44 @@ describe('useStep', () => {
     expect(prevStepActionMockFn).toBeCalled();
   });
 
+  it('should handle infinite steps', async () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 3, infinite: true })
+    );
+
+    await waitFor(() => {
+      result.current.prevStep();
+    });
+
+    expect(result.current.currentStep).toBe(3);
+
+    await waitFor(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.currentStep).toBe(1);
+  });
+
+  it('should handle infinite steps and call the provided action', async () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 3, infinite: true })
+    );
+
+    await waitFor(() => {
+      result.current.prevStep(prevStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(3);
+    expect(prevStepActionMockFn).toBeCalledTimes(1);
+
+    await waitFor(() => {
+      result.current.nextStep(nextStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(1);
+    expect(nextStepActionMockFn).toBeCalledTimes(1);
+  });
+
   it('should set the step correctly when a number is provided', async () => {
     const { result } = renderHook(() => useStep({ maxStep: 3 }));
 
@@ -126,7 +164,7 @@ describe('useStep', () => {
     expect(setStepActionMockFn).toBeCalledTimes(1);
   });
 
-  it('should reset to the initial step and update state correctly', async () => {
+  it('should reset to the initial step', async () => {
     const { result } = renderHook(() =>
       useStep({ maxStep: 3, initialStep: 2 })
     );

--- a/packages/react/src/hooks/useStep/useStep.spec.ts
+++ b/packages/react/src/hooks/useStep/useStep.spec.ts
@@ -1,0 +1,161 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { useStep } from '.';
+
+describe('useStep', () => {
+  const nextStepActionMockFn = vi.fn();
+  const prevStepActionMockFn = vi.fn();
+  const setStepActionMockFn = vi.fn();
+  const resetStepActionMockFn = vi.fn();
+
+  it('should initialize with the initial step', () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 3, initialStep: 2 })
+    );
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.hasNextStep).toBe(true);
+    expect(result.current.hasPrevStep).toBe(true);
+  });
+
+  it('should go to the next step and update state correctly', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    await waitFor(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.hasNextStep).toBe(true);
+
+    await waitFor(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.currentStep).toBe(3);
+    expect(result.current.hasNextStep).toBe(false);
+
+    await waitFor(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.currentStep).toBe(3);
+    expect(result.current.hasNextStep).toBe(false);
+  });
+
+  it('should go to the next step and call the provided action', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    await waitFor(() => {
+      result.current.nextStep(nextStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(nextStepActionMockFn).toBeCalled();
+  });
+
+  it('should go to the previous step and update state correctly', async () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 4, initialStep: 3 })
+    );
+
+    await waitFor(() => {
+      result.current.prevStep();
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.hasPrevStep).toBe(true);
+
+    await waitFor(() => {
+      result.current.prevStep();
+    });
+
+    expect(result.current.currentStep).toBe(1);
+    expect(result.current.hasPrevStep).toBe(false);
+
+    await waitFor(() => {
+      result.current.prevStep();
+    });
+
+    expect(result.current.currentStep).toBe(1);
+    expect(result.current.hasPrevStep).toBe(false);
+  });
+
+  it('should go to the previous step and call the provided action', async () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 3, initialStep: 2 })
+    );
+
+    await waitFor(() => {
+      result.current.prevStep(prevStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(1);
+    expect(prevStepActionMockFn).toBeCalled();
+  });
+
+  it('should set the step correctly when a number is provided', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    // setStep number
+    await waitFor(() => {
+      result.current.setStep(2);
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.hasNextStep).toBe(true);
+    expect(result.current.hasPrevStep).toBe(true);
+
+    // setStep Function
+    await waitFor(() => {
+      result.current.setStep((currentStep) => currentStep + 1);
+    });
+
+    expect(result.current.currentStep).toBe(3);
+    expect(result.current.hasNextStep).toBe(false);
+    expect(result.current.hasPrevStep).toBe(true);
+  });
+
+  it('should set the step correctly and call the provided action', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    await waitFor(() => {
+      result.current.setStep(2, setStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(setStepActionMockFn).toBeCalledTimes(1);
+  });
+
+  it('should reset to the initial step and update state correctly', async () => {
+    const { result } = renderHook(() =>
+      useStep({ maxStep: 3, initialStep: 2 })
+    );
+
+    await waitFor(() => {
+      result.current.resetStep();
+    });
+
+    expect(result.current.currentStep).toBe(2);
+    expect(result.current.hasPrevStep).toBe(true);
+    expect(result.current.hasNextStep).toBe(true);
+  });
+
+  it('should reset to the initial step and call the provided action', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    await waitFor(() => {
+      result.current.resetStep(resetStepActionMockFn);
+    });
+
+    expect(result.current.currentStep).toBe(1);
+    expect(resetStepActionMockFn).toBeCalledTimes(1);
+  });
+
+  it('should throw error for invalid step', async () => {
+    const { result } = renderHook(() => useStep({ maxStep: 3 }));
+
+    await waitFor(() => {
+      expect(() => result.current.setStep(4)).toThrow('Step not valid');
+    });
+  });
+});


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/252

`mult-step process`의 `step`을 관리하고 추적해주는 커스텀 훅입니다.

내부적으로 쿼리스트링과 router에 의존하는 slash/Funnel과는 차이가 있는 훅입니다.

해당 훅은 router 등과 의존성이 없이 단순히 multi-step 프로세스에서 step을 관리하기 위한 커스텀 훅입니다. 
multi-step process의 대표적인 예로 `carousel slider` 가 있습니다.

해당 훅을 선언적으로 활용하기 위한 `Step` 컴포넌트까지 추후 작업이 가능합니다.

nextStep, preStep 등은 인자로 action을 받아 추가적인 행동을 취할 수 있습니다.

## Example
### Default
https://github.com/modern-agile-team/modern-kit/assets/64779472/5ebaddb6-ef41-4818-b7c6-bc809f82a3aa

### Infinite
https://github.com/modern-agile-team/modern-kit/assets/64779472/da677687-528a-4ae1-b28c-586b72bedf8b

## Reference
https://usehooks-ts.com/react-hook/use-step


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)