### PR TITLE
fix(react): useVhProperty 옵션 및 문서 수정

### DIFF
--- a/.changeset/eight-seals-know.md
+++ b/.changeset/eight-seals-know.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+fix(react): useVhProperty 옵션 및 문서 수정 - @ssi02014

--- a/docs/docs/react/hooks/useMouse.mdx
+++ b/docs/docs/react/hooks/useMouse.mdx
@@ -58,7 +58,7 @@ const Example = () => {
   return (
     <>
       <div ref={ref} style={boxStyle}>
-        박스 안에서 마우스를 움직여보세요.
+        마우스를 움직여보세요.
       </div>
       <p>사용자 모니터 내 X좌표: {position.screenX}</p>
       <p>사용자 모니터 내 Y좌표: {position.screenY}</p>
@@ -93,7 +93,7 @@ export const Example = () => {
   return (
     <>
       <div ref={ref} style={boxStyle}>
-        박스 안에서 마우스를 움직여보세요.
+        마우스를 움직여보세요.
       </div>
       <p>사용자 모니터 내 X좌표: {position.screenX}</p>
       <p>사용자 모니터 내 Y좌표: {position.screenY}</p>

--- a/docs/docs/react/hooks/useVhProperty.mdx
+++ b/docs/docs/react/hooks/useVhProperty.mdx
@@ -33,14 +33,12 @@ const Example = () => {
   useVhProperty(); 
   // Resize: useVhProperty({ enableResize: true });
 
-
-  const style = useMemo(() => {
+  const style: CSSProperties = useMemo(() => {
     return {
       height: 'calc(var(--vh, 1vh) * 100)',
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      flexDirection: 'column',
       background: 'purple',
       fontSize: '2rem',
       color: '#fff',
@@ -50,7 +48,6 @@ const Example = () => {
   return (
     <div style={style}>
       <p>100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.</p>
-      <p>--vh: {`${document.documentElement.style.getPropertyValue('--vh')}`}</p>
     </div>
   );
 };
@@ -66,7 +63,6 @@ export const Example = () => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
-      flexDirection: 'column',
       background: 'purple',
       fontSize: '2rem',
       color: '#fff',
@@ -76,7 +72,6 @@ export const Example = () => {
   return (
     <div style={style}>
       <p>100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.</p>
-      <p>--vh: {`${document.documentElement.style.getPropertyValue('--vh')}`}</p>
     </div>
   );
 };

--- a/docs/docs/react/hooks/useVhProperty.mdx
+++ b/docs/docs/react/hooks/useVhProperty.mdx
@@ -17,12 +17,12 @@ iOS 웹 환경에서는 주소표시줄의 높이로 인해 100vh가 실제 보�
 ## Interface
 ```ts title="typescript"
 
-interface Options {
+interface UseVhPropertyProps {
+  name?: string;
   enableResize?: boolean;
 }
 
-const useVhProperty: (name?: string, options?: Options) => void
-
+const useVhProperty: ({ name, enableResize }?: UseVhPropertyProps) => void;
 ```
 
 ## Usage

--- a/docs/docs/react/hooks/useVhProperty.mdx
+++ b/docs/docs/react/hooks/useVhProperty.mdx
@@ -7,7 +7,7 @@ iOS 웹 환경에서는 주소표시줄의 높이로 인해 100vh가 실제 보�
 
 이를 해결하기 위해 `useVhProperty` 훅을 사용하면 `100vh`를 실제 화면의 높이로 계산할 수 있도록 css변수를 설정할 수 있습니다.
 
-일반적으로 iOS 환경에서 resize는 가로/세로 전환시에만 발생하지만, 두번째 인자의 enableResize를 옵션을 사용하면 iOS 환경에서도 resize 이벤트가 발생할 때마다 css변수를 다시 계산할 수 있습니다.
+일반적으로 iOS 환경에서 resize는 가로/세로 전환시에만 발생하지만, 두번째 인자의 `enableResize`를 옵션을 사용하면 iOS 환경에서도 `resize` 이벤트가 발생할 때마다 css변수를 다시 계산할 수 있습니다.
 
 <br />
 
@@ -30,7 +30,9 @@ const useVhProperty: (name?: string, options?: Options) => void
 import { useVhProperty } from '@modern-kit/react';
 
 const Example = () => {
-  useVhProperty()
+  useVhProperty(); 
+  // Resize: useVhProperty({ enableResize: true });
+
 
   const style = useMemo(() => {
     return {
@@ -38,6 +40,7 @@ const Example = () => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      flexDirection: 'column',
       background: 'purple',
       fontSize: '2rem',
       color: '#fff',
@@ -46,7 +49,8 @@ const Example = () => {
 
   return (
     <div style={style}>
-      100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.
+      <p>100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.</p>
+      <p>--vh: {`${document.documentElement.style.getPropertyValue('--vh')}`}</p>
     </div>
   );
 };
@@ -62,6 +66,7 @@ export const Example = () => {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'center',
+      flexDirection: 'column',
       background: 'purple',
       fontSize: '2rem',
       color: '#fff',
@@ -70,7 +75,8 @@ export const Example = () => {
 
   return (
     <div style={style}>
-      100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.
+      <p>100vh를 실제 화면의 높이로 계산할 수 있도록 설정해줍니다.</p>
+      <p>--vh: {`${document.documentElement.style.getPropertyValue('--vh')}`}</p>
     </div>
   );
 };

--- a/packages/react/src/hooks/useVhProperty/index.ts
+++ b/packages/react/src/hooks/useVhProperty/index.ts
@@ -1,13 +1,14 @@
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 
-interface Options {
+interface UseVhPropertyProps {
   name?: string;
   enableResize?: boolean;
 }
 
-export const useVhProperty = (options: Options = {}) => {
-  const { name = 'vh', enableResize = false } = options;
-
+export const useVhProperty = ({
+  name = 'vh',
+  enableResize = false,
+}: UseVhPropertyProps = {}) => {
   useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
       const vh = window.innerHeight * 0.01;

--- a/packages/react/src/hooks/useVhProperty/index.ts
+++ b/packages/react/src/hooks/useVhProperty/index.ts
@@ -1,14 +1,12 @@
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 
 interface Options {
+  name?: string;
   enableResize?: boolean;
 }
 
-export const useVhProperty = (
-  name: string = 'vh',
-  options: Options = { enableResize: false },
-) => {
-  const { enableResize } = options;
+export const useVhProperty = (options: Options = {}) => {
+  const { name = 'vh', enableResize = false } = options;
 
   useIsomorphicLayoutEffect(() => {
     const handleResize = () => {

--- a/packages/react/src/hooks/useVhProperty/index.ts
+++ b/packages/react/src/hooks/useVhProperty/index.ts
@@ -2,12 +2,12 @@ import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
 
 interface UseVhPropertyProps {
   name?: string;
-  enableResize?: boolean;
+  enabledResize?: boolean;
 }
 
 export const useVhProperty = ({
   name = 'vh',
-  enableResize = false,
+  enabledResize = false,
 }: UseVhPropertyProps = {}) => {
   useIsomorphicLayoutEffect(() => {
     const handleResize = () => {
@@ -17,14 +17,14 @@ export const useVhProperty = ({
 
     handleResize();
 
-    if (enableResize) {
+    if (enabledResize) {
       window.addEventListener('resize', handleResize);
     }
 
     return () => {
-      if (enableResize) {
+      if (enabledResize) {
         window.removeEventListener('resize', handleResize);
       }
     };
-  }, [name, enableResize]);
+  }, [name, enabledResize]);
 };

--- a/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
+++ b/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
@@ -20,7 +20,7 @@ describe('useVhProperty', () => {
     window.innerHeight = 800;
     renderHook(() =>
       useVhProperty({
-        enableResize: true,
+        enabledResize: true,
       })
     );
     expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');

--- a/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
+++ b/packages/react/src/hooks/useVhProperty/useVhProperty.spec.ts
@@ -10,18 +10,18 @@ describe('useVhProperty', () => {
 
   it('should set --custom property on documentElement', () => {
     window.innerHeight = 800;
-    renderHook(() => useVhProperty('custom'));
+    renderHook(() => useVhProperty({ name: 'custom' }));
     expect(document.documentElement.style.getPropertyValue('--custom')).toBe(
-      '8px',
+      '8px'
     );
   });
 
   it('should set --vh property on documentElement and update on resize', () => {
     window.innerHeight = 800;
     renderHook(() =>
-      useVhProperty('vh', {
+      useVhProperty({
         enableResize: true,
-      }),
+      })
     );
     expect(document.documentElement.style.getPropertyValue('--vh')).toBe('8px');
 


### PR DESCRIPTION
## Overview

기존 useVhProperty의 enabledResize 옵션을 사용하려면 무조건 name 인자를 추가해줘야한다는 불편함이 있었습니다.
따라서 이런 불편함을 해결하기 위해 하나의 options로 변경합니다. -> 네이밍도 `UseVhPropertyProps`로 변경합니다.

추가로 boolean형태의 옵션 네이밍에서 enable보다 enabled 형태가 많이 사용되는 것 같아 enableResize에서 enabledResize 로 네이밍을 변경합니다. 🙏

```ts
// as-is
// name이 기본 값과 동일한 'vh'임에도 넣어줘야했음
useVhProperty('vh', {
  enableResize: true,
})

// to-be
useVhProperty({
  enabledResize: true,
})
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)