### PR TITLE
chore(utils): intersection 내부구현 수정 완료

### DIFF
--- a/.changeset/two-jars-reflect.md
+++ b/.changeset/two-jars-reflect.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/utils": patch
+---
+
+chore(utils): intersection 내부구현 수정 완료

--- a/packages/utils/src/array/intersection/index.ts
+++ b/packages/utils/src/array/intersection/index.ts
@@ -1,25 +1,18 @@
 import { identity } from '../../common';
 
+import { intersectionWithDuplicates } from '../intersectionWithDuplicates';
+import { uniq } from '../uniq';
+
 export const intersection = <T, U = T>(
   firstArr: T[] | readonly T[],
   secondArr: T[] | readonly T[],
   iteratee: (item: T) => T | U = identity,
 ) => {
-  const appliedIterateeSecondSet = new Set(secondArr.map(iteratee));
+  const intersection = intersectionWithDuplicates(
+    firstArr,
+    secondArr,
+    iteratee,
+  );
 
-  const intersection = [];
-  const checkedSet = new Set();
-
-  for (const item of firstArr) {
-    const appliedIterateeFirstArrItem = iteratee(item);
-
-    if (checkedSet.has(appliedIterateeFirstArrItem)) continue;
-
-    if (appliedIterateeSecondSet.has(appliedIterateeFirstArrItem)) {
-      intersection.push(item);
-      checkedSet.add(appliedIterateeFirstArrItem);
-    }
-  }
-
-  return intersection;
+  return uniq(intersection, iteratee);
 };

--- a/packages/utils/src/array/intersection/index.ts
+++ b/packages/utils/src/array/intersection/index.ts
@@ -1,7 +1,6 @@
 import { identity } from '../../common';
 
-import { intersectionWithDuplicates } from '../intersectionWithDuplicates';
-import { uniq } from '../uniq';
+import { intersectionWithDuplicates, uniq } from '..';
 
 export const intersection = <T, U = T>(
   firstArr: T[] | readonly T[],


### PR DESCRIPTION
## Overview

Issue: #265 

별도의 함수를 두어 계산하던 중복제거 intersection을 가독성을 위해 intersectionWithDuplicates와 uniq 함수의 조합으로 변경하였습니다.

내부구현만 변경하였기에 테스트코드와 문서에는 수정사항이 없습니다.

## PR Checklist
- [ ] All tests pass.
- [ ] All type checks pass.
- [ ] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)