### PR TITLE
fix(utils): excludeElements 성능 개선을 위해 인터페이스 변경

### DIFF
--- a/.changeset/poor-cheetahs-admire.md
+++ b/.changeset/poor-cheetahs-admire.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': patch
+---
+
+fix(utils): excludeElements 성능 개선을 위해 인터페이스 변경 - @ssi02014

--- a/docs/docs/utils/array/excludeElements.md
+++ b/docs/docs/utils/array/excludeElements.md
@@ -1,10 +1,9 @@
 # excludeElements
 
-1번째 매개변수로 전달된 배열에서, 2번째 이후의 값을 제외하여 반환하는 유틸 함수입니다.
+1번째 매개변수로 전달된 배열을 기준으로 2번째 배열의 요소들을 제외하는 유틸 함수입니다.
 
 원시값의 경우 명확한 타입체크를 위해 `as const` 사용을 권장드립니다.  
-원시값이 아닌 `object` 타입인 경우 `JSON.stringify`를 통해 동등성을 비교합니다.
-
+기본적으로 원시값에 대한 비교를 진행하며, 참조형의 경우 3번째 `iteratee` 함수 결과를 통해 제외 할 요소를 결정 할 수 있습니다.
 
 <br />
 
@@ -13,9 +12,10 @@
 
 ## Interface
 ```ts title="typescript"
-const excludeElements: <T, U extends T>(
+const excludeElements: <T, U = T>(
   array: T[] | readonly T[],
-  ...args: U[] | readonly U[]
+  args: T[] | readonly T[],
+  iteratee?: (item: T) => U
 ) => T[];
 ```
 
@@ -26,7 +26,7 @@ import { excludeElements } from '@modern-kit/utils';
 const array = [1, 2, 3, 4];
 const excluded = [3, 4]
 
-excludeElements(array, ...excluded); // [1, 2]
+excludeElements(array, excluded); // [1, 2]
 ```
 
 ```ts title="typescript"
@@ -35,7 +35,7 @@ import { excludeElements } from '@modern-kit/utils';
 const array = ['a', 'b', 'c', 'd'];
 const excluded = ['a']
 
-excludeElements(array, ...excluded); // ['b', 'c', 'd']
+excludeElements(array, excluded); // ['b', 'c', 'd']
 ```
 
 ```ts title="typescript"
@@ -44,7 +44,7 @@ import { excludeElements } from '@modern-kit/utils';
 const array = [[3, 'a'], [4, 'b']];
 const excluded = [[3, 'a']]
 
-excludeElements(array, ...excluded); // [4, 'b']
+excludeElements(array, excluded, (item) => JSON.stringify(item)); // [4, 'b']
 ```
 
 ```ts title="typescript"
@@ -56,9 +56,5 @@ const array = [
 ];
 const excluded = [{ name: 'kim', address: { city: 'Seoul' } }];
 
-excludeElements(array, ...excluded); // { name: 'lee', address: { city: 'NewYork' } }
+excludeElements(array, excluded, (item) => item.name); // { name: 'lee', address: { city: 'NewYork' } }
 ```
-
-## Caveats
-
-- 2번째 이후의 매개변수의 형태는 `이터러블` 혹은 `리스트(1, 2, 3..)` 형태입니다.

--- a/docs/docs/utils/array/excludeElements.md
+++ b/docs/docs/utils/array/excludeElements.md
@@ -14,7 +14,7 @@
 ```ts title="typescript"
 const excludeElements: <T, U = T>(
   array: T[] | readonly T[],
-  args: T[] | readonly T[],
+  excludeArray: T[] | readonly T[],
   iteratee?: (item: T) => U
 ) => T[];
 ```

--- a/packages/utils/src/array/excludeElements/excludeElements.spec.ts
+++ b/packages/utils/src/array/excludeElements/excludeElements.spec.ts
@@ -2,43 +2,48 @@ import { excludeElements } from '.';
 
 describe('excludeElements', () => {
   it('filter after second parameter values from first parameter.', () => {
-    const array = [1, 2, 3, 4, 5, 6];
-    const excludedElements = [1, 3];
+    const array = [1, 2, 3, 4, 5, 6] as const;
+    const excludedElements = [1, 3] as const;
 
-    expect(excludeElements(array, ...excludedElements)).toEqual([2, 4, 5, 6]);
+    expect(excludeElements(array, excludedElements)).toEqual([2, 4, 5, 6]);
   });
 
   it('should filter boolean.', () => {
     const array = [true, false, false, true];
     const excludedElements = [true];
 
-    expect(excludeElements(array, ...excludedElements)).toEqual([false, false]);
+    expect(excludeElements(array, excludedElements)).toEqual([false, false]);
   });
 
   it('should filter string.', () => {
     const array = ['name', 'value', 'value', 'key'];
     const excludedElements = ['value'];
 
-    expect(excludeElements(array, ...excludedElements)).toEqual([
-      'name',
-      'key',
-    ]);
+    expect(excludeElements(array, excludedElements)).toEqual(['name', 'key']);
   });
 
   it('should filter object.', () => {
-    const excludePerson = { name: 'kim', address: { city: 'Seoul' } };
-    const notExcludePerson = { name: 'lee', address: { city: 'NewYork' } };
+    const people = [
+      { name: 'kim', address: { city: 'Seoul' } },
+      { name: 'lee', address: { city: 'NewYork' } },
+      { name: 'kim', address: { city: 'Seoul' } },
+    ];
 
-    const people = [excludePerson];
-
-    expect(excludeElements(people, excludePerson)).toEqual([]);
-    expect(excludeElements(people, notExcludePerson)).toEqual(people);
+    expect(
+      excludeElements(
+        people,
+        [{ name: 'kim', address: { city: 'Seoul' } }],
+        (item) => item.name
+      )
+    ).toEqual([{ name: 'lee', address: { city: 'NewYork' } }]);
   });
 
   it('should filter tuple.', () => {
     const array = [[3, 'a']];
     const excludedElements = [3, 'a'];
 
-    expect(excludeElements(array, excludedElements)).toEqual([]);
+    expect(
+      excludeElements(array, [excludedElements], (item) => JSON.stringify(item))
+    ).toEqual([]);
   });
 });

--- a/packages/utils/src/array/excludeElements/excludeElements.spec.ts
+++ b/packages/utils/src/array/excludeElements/excludeElements.spec.ts
@@ -2,8 +2,8 @@ import { excludeElements } from '.';
 
 describe('excludeElements', () => {
   it('filter after second parameter values from first parameter.', () => {
-    const array = [1, 2, 3, 4, 5, 6] as const;
-    const excludedElements = [1, 3] as const;
+    const array = [1, 2, 3, 4, 5, 6];
+    const excludedElements = [1, 3];
 
     expect(excludeElements(array, excludedElements)).toEqual([2, 4, 5, 6]);
   });
@@ -39,11 +39,15 @@ describe('excludeElements', () => {
   });
 
   it('should filter tuple.', () => {
-    const array = [[3, 'a']];
+    const array = [
+      [3, 'a'],
+      [4, 'b'],
+      [3, 'a'],
+    ];
     const excludedElements = [3, 'a'];
 
     expect(
       excludeElements(array, [excludedElements], (item) => JSON.stringify(item))
-    ).toEqual([]);
+    ).toEqual([[4, 'b']]);
   });
 });

--- a/packages/utils/src/array/excludeElements/index.ts
+++ b/packages/utils/src/array/excludeElements/index.ts
@@ -2,10 +2,10 @@ import { identity } from '../../common';
 
 export const excludeElements = <T, U = T>(
   array: T[] | readonly T[],
-  args: T[] | readonly T[],
+  excludeArray: T[] | readonly T[],
   iteratee: (item: T) => U = identity as (item: T) => U
 ) => {
-  const excludeSet = new Set(args.map(iteratee));
+  const excludeSet = new Set(excludeArray.map(iteratee));
 
   return array.filter((element) => !excludeSet.has(iteratee(element)));
 };

--- a/packages/utils/src/array/excludeElements/index.ts
+++ b/packages/utils/src/array/excludeElements/index.ts
@@ -1,8 +1,11 @@
-export const excludeElements = <T, U extends T>(
-  array: T[] | readonly T[],
-  ...args: T[] | readonly U[]
-) => {
-  const excludeSet = new Set(args.map((arg) => JSON.stringify(arg)));
+import { identity } from '../../common';
 
-  return array.filter((element) => !excludeSet.has(JSON.stringify(element)));
+export const excludeElements = <T, U = T>(
+  array: T[] | readonly T[],
+  args: T[] | readonly T[],
+  iteratee: (item: T) => U = identity as (item: T) => U
+) => {
+  const excludeSet = new Set(args.map(iteratee));
+
+  return array.filter((element) => !excludeSet.has(iteratee(element)));
 };


### PR DESCRIPTION
## Overview

cc. @Collection50 

excludeElements 성능 개선을 위해 인터페이스 및 내부 로직 변경합니다.

매번 `JSON.stringify`를 하는 것은 불 필요합니다. 필요한 경우 3번째 인자로 `iteratee` 함수를 넣는 방향으로 변경합니다.
이를 통해, 사용자가  제거 할 요소를 결정하는데 `자유롭게`결정 할 수 있으며 성능도 개선 할 수 있습니다. 
  - 예를 들어 객체의 경우 단순 프로퍼티 접근을 통해 결정 할 수 있습니다. 
  - iteratee의 기본 함수는 `identity` 함수입니다.

또한, 이런 변화를 통해 2번째 인자는 앞으로 배열을 넣어줘야 합니다.

### 원시타입 배열
```ts
excludeElements([1, 2, 3, 4, 5, 6], [1, 3]); // [2, 4, 5, 6]
```

### 프로퍼티 접근
```ts
const people = [
  { name: 'kim', address: { city: 'Seoul' } },
  { name: 'lee', address: { city: 'NewYork' } },
  { name: 'kim', address: { city: 'Seoul' } },
];

excludeElements(
  people,
  [{ name: 'kim', address: { city: 'Seoul' } }],
  (item) => item.name
);
// name으로 판단
// [{ name: 'lee', address: { city: 'NewYork' } }]
```

### JSON.stringify 사용
```ts
const array = [
  [3, 'a'],
  [4, 'b'],
  [3, 'a'],
];
const excludedElements = [3, 'a'];

excludeElements(array, [excludedElements], (item) => JSON.stringify(item));
// [[4, 'b']]
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)