### PR TITLE
feat(react): SeparatedIterator 신규 컴포넌트 추가

### DIFF
--- a/.changeset/curly-rivers-relate.md
+++ b/.changeset/curly-rivers-relate.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): SeparatedIterator 신규 컴포넌트 추가 - @ssi02014

--- a/docs/docs/react/components/Iterator.mdx
+++ b/docs/docs/react/components/Iterator.mdx
@@ -2,7 +2,7 @@ import { Iterator } from '@modern-kit/react';
 
 # Iterator
 
-`items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 선언적으로 렌더링할 수 있는 컴포넌트입니다.
+`items props`로 주어진 배열을 반복하면서, 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링할 수 있는 컴포넌트입니다.
 
 <br />
 
@@ -43,7 +43,7 @@ const Example = () => {
       items={items}
       renderItem={(item) => (
         <h3>
-          id: {item.id}, name:{item.name}
+          id: {item.id}, name: {item.name}
         </h3>
       )}
     />
@@ -65,7 +65,7 @@ export const Example = () => {
       items={items}
       renderItem={(item) => (
         <h3>
-          id: {item.id}, name:{item.name}
+          id: {item.id}, name: {item.name}
         </h3>
       )}
     />

--- a/docs/docs/react/components/SeparatedIterator.mdx
+++ b/docs/docs/react/components/SeparatedIterator.mdx
@@ -2,9 +2,9 @@ import { SeparatedIterator } from '@modern-kit/react';
 
 # SeparatedIterator
 
-`items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 Separator를 렌더링 하는 유틸 컴포넌트입니다.
+[Iterator](https://modern-agile-team.github.io/modern-kit/docs/react/components/Iterator)를 확장해 `items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 `Separator`를 렌더링 하는 컴포넌트입니다.
 
-기본적으로 마지막 요소 다음 Separator는 제외됩니다. `includeLastSeparator`를 `true`로 설정해서 포함시킬 수 있습니다.
+기본적으로 마지막 요소 다음 `Separator`는 제외됩니다. `includeLastSeparator`를 `true`로 설정해서 포함시킬 수 있습니다.
 
 <br />
 

--- a/docs/docs/react/components/SeparatedIterator.mdx
+++ b/docs/docs/react/components/SeparatedIterator.mdx
@@ -1,0 +1,79 @@
+import { SeparatedIterator } from '@modern-kit/react';
+
+# SeparatedIterator
+
+`items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 Separator를 렌더링 하는 유틸 컴포넌트입니다.
+
+기본적으로 마지막 요소 다음 Separator는 제외됩니다. `includeLastSeparator`를 `true`로 설정해서 포함시킬 수 있습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/SeparatedIterator/index.tsx)
+
+## Interface
+```ts title="typescript"
+interface SeparatedIteratorProps<T> extends IteratorProps<T> {
+  separator: JSX.Element;
+  includeLastSeparator?: boolean;
+}
+
+const SeparatedIterator: <T extends unknown>({
+  items,
+  renderItem,
+  separator,
+  includeLastSeparator,
+}: SeparatedIteratorProps<T>) => JSX.Element;
+```
+
+## Usage
+```tsx title="typescript"
+import { SeparatedIterator } from '@modern-kit/react';
+
+interface Item {
+  id: number;
+  name: string;
+}
+
+const Example = () => {
+  const items: Item[] = [
+    { id: 1, name: 'Gromit' },
+    { id: 2, name: 'Dylan' },
+    { id: 3, name: 'Minjae' },
+  ];
+
+  return (
+    <SeparatedIterator
+      items={items}
+      renderItem={(item) => (
+        <h3>
+          id: {item.id}, name: {item.name}
+        </h3>
+      )}
+      separator={<div style={{ height: '3px', backgroundColor: 'gray' }} />}
+    />
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const items = [
+    { id: 1, name: 'Gromit' },
+    { id: 2, name: 'Dylan' },
+    { id: 3, name: 'Minjae' },
+  ];
+
+  return (
+    <SeparatedIterator
+      items={items}
+      renderItem={(item) => (
+        <h3>id: {item.id}, name: {item.name}</h3>
+      )}
+      separator={<div style={{ height: '3px', backgroundColor: 'gray' }} />}
+    />
+  );
+};
+
+<Example />

--- a/packages/react/src/components/SeparatedIterator/SeparatedIterator.spec.tsx
+++ b/packages/react/src/components/SeparatedIterator/SeparatedIterator.spec.tsx
@@ -1,0 +1,49 @@
+import { renderSetup } from '../../utils/test/renderSetup';
+import { screen } from '@testing-library/react';
+import { SeparatedIterator } from '.';
+
+interface TestItem {
+  id: number;
+  name: string;
+}
+
+const testItems: TestItem[] = [
+  { id: 1, name: 'Item 1' },
+  { id: 2, name: 'Item 2' },
+  { id: 3, name: 'Item 3' },
+];
+
+describe('SeparatedIterator', () => {
+  it('should render the correct number of items with separators', () => {
+    renderSetup(
+      <SeparatedIterator
+        items={testItems}
+        renderItem={(item) => <div>{item.name}</div>}
+        separator={<div>separator</div>}
+      />
+    );
+
+    const renderItems = screen.getAllByText(/Item \d/);
+    const separators = screen.getAllByText(/separator/);
+
+    expect(renderItems).toHaveLength(testItems.length);
+    expect(separators).toHaveLength(testItems.length - 1);
+  });
+
+  it('should render the correct number of separators when includeLastSeparator is true', () => {
+    renderSetup(
+      <SeparatedIterator
+        items={testItems}
+        renderItem={(item) => <div>{item.name}</div>}
+        separator={<div>separator</div>}
+        includeLastSeparator
+      />
+    );
+
+    const renderItems = screen.getAllByText(/Item \d/);
+    const separators = screen.getAllByText(/separator/);
+
+    expect(renderItems).toHaveLength(testItems.length);
+    expect(separators).toHaveLength(testItems.length);
+  });
+});

--- a/packages/react/src/components/SeparatedIterator/index.tsx
+++ b/packages/react/src/components/SeparatedIterator/index.tsx
@@ -1,0 +1,25 @@
+import { Iterator, IteratorProps } from '../Iterator';
+
+interface SeparatedIteratorProps<T> extends IteratorProps<T> {
+  separator: JSX.Element;
+  includeLastSeparator?: boolean;
+}
+
+export const SeparatedIterator = <T extends unknown>({
+  items,
+  renderItem,
+  separator,
+  includeLastSeparator = false,
+}: SeparatedIteratorProps<T>) => {
+  return (
+    <Iterator
+      items={items}
+      renderItem={(item, index) => (
+        <>
+          {renderItem(item, index)}
+          {(includeLastSeparator || index < items.length - 1) && separator}
+        </>
+      )}
+    />
+  );
+};

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -5,5 +5,6 @@ export * from './Iterator';
 export * from './LazyImage';
 export * from './OutsideClick';
 export * from './Portal';
+export * from './SeparatedIterator';
 export * from './When';
 export * from './SwitchCase';


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/269

[Iterator](https://modern-agile-team.github.io/modern-kit/docs/react/components/Iterator)를 확장해 `items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 `Separator`를 렌더링 하는 컴포넌트입니다.

기본적으로 마지막 요소 다음 `Separator`는 제외됩니다. `includeLastSeparator`를 `true`로 설정해서 포함시킬 수 있습니다.

```tsx
<SeparatedIterator
  items={items}
  renderItem={(item) => <h3>{item}</h3>}
  separator={<Divider />}
/>
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)