### PR TITLE
feat(utils): isReference 유틸 함수 추가

### DIFF
--- a/.changeset/afraid-ravens-rescue.md
+++ b/.changeset/afraid-ravens-rescue.md
@@ -1,5 +1,5 @@
 ---
-'@modern-kit/utils': major
+'@modern-kit/utils': minor
 ---
 
 feat(utils): isReference 유틸 함수 추가 - @Gaic4o

--- a/.changeset/afraid-ravens-rescue.md
+++ b/.changeset/afraid-ravens-rescue.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': major
+---
+
+feat(utils): isReference 유틸 함수 추가 - @Gaic4o

--- a/docs/docs/utils/validator/isReference.md
+++ b/docs/docs/utils/validator/isReference.md
@@ -1,0 +1,46 @@
+# isReference
+
+`참조 타입`은 객체, 배열, 함수 등 `비원시 타입`을 포함합니다. 주어진 인자가 `참조 타입`인지 여부를 확인하는 함수입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/validator/isReference/index.ts)
+
+## Interface 
+```ts title="typescript"
+export type Reference =
+  | object
+  | any[]
+  | Function
+  | Set<any>
+  | Map<any, any>
+  | WeakMap<object, any>
+  | WeakSet<object>
+  | Date
+  | RegExp
+  | Error;
+
+const isReference: (value: unknown) => value is Reference
+```
+
+## Usage 
+```ts title="typescript"
+import { isReference } from '@modern-kit/utils';
+
+isReference({}); // true
+isReference([]); // true
+isReference(new Set()); // true
+isReference(new Map()); // true
+isReference(new WeakSet()); // true
+isReference(new WeakMap()); // true
+isReference(new Date()); // true
+isReference(new Error()); // true
+
+isReference(null); // false
+isReference(undefined); // false
+isReference('string'); // false
+isReference(1); // false
+isReference(false); // false
+isReference(Symbol()); // false
+```

--- a/packages/utils/src/validator/index.ts
+++ b/packages/utils/src/validator/index.ts
@@ -9,6 +9,7 @@ export * from './isNullish';
 export * from './isNumber';
 export * from './isPrimitive';
 export * from './isPromise';
+export * from './isReference';
 export * from './isString';
 export * from './isValidEmail';
 export * from './isValidPassword';

--- a/packages/utils/src/validator/isReference/index.ts
+++ b/packages/utils/src/validator/isReference/index.ts
@@ -1,0 +1,6 @@
+import { Reference } from '@modern-kit/types';
+import { isPrimitive } from '../isPrimitive';
+
+export const isReference = (value: unknown): value is Reference => {
+  return !isPrimitive(value);
+};

--- a/packages/utils/src/validator/isReference/isReference.spec.ts
+++ b/packages/utils/src/validator/isReference/isReference.spec.ts
@@ -1,0 +1,24 @@
+import { isReference } from '.';
+
+describe('isReference', () => {
+  it('should return true for reference types', () => {
+    expect(isReference({})).toBe(true);
+    expect(isReference([])).toBe(true);
+    expect(isReference(new Set())).toBe(true);
+    expect(isReference(new Map())).toBe(true);
+    expect(isReference(new WeakSet())).toBe(true);
+    expect(isReference(new WeakMap())).toBe(true);
+    expect(isReference(new Date())).toBe(true);
+    expect(isReference(new Error())).toBe(true);
+    expect(isReference(() => {})).toBe(true);
+  });
+
+  it('should return false for primitive types', () => {
+    expect(isReference(null)).toBe(false);
+    expect(isReference(undefined)).toBe(false);
+    expect(isReference('string')).toBe(false);
+    expect(isReference(false)).toBe(false);
+    expect(isReference(1)).toBe(false);
+    expect(isReference(Symbol())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #218 

주어진 인자가 `참조 타입`인지 여부를 확인하는 함수입니다.

```javascript
const reference = isReference({}); // true
const reference = isReference([]); // true
const reference = isReference(new Set()); // true
const reference = isReference(new Map()); // true
const reference = isReference(new WeakSet()); // true
const reference = isReference(new WeakMap()); // true
const reference = isReference(new Date()); // true
const reference = isReference(new Error()); // true
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)