### PR TITLE
feat(utils): flatten 신규 유틸 함수 추가

### DIFF
--- a/.changeset/quick-dolphins-serve.md
+++ b/.changeset/quick-dolphins-serve.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): flatten 신규 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/array/flatten.md
+++ b/docs/docs/utils/array/flatten.md
@@ -1,6 +1,6 @@
 # flatten
 
-중첩 배열을 평탄화해주는 함수입니다.
+중첩 배열을 `평탄화`해주는 함수입니다. `depth` 옵션으로 평탄화 깊이를 직접 지정 할 수 있습니다.
 
 JS에서 기본적으로 제공하는 [flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)은 기본적으로 성능이 안좋습니다.
 
@@ -24,8 +24,8 @@ type FlatArray<Arr, Depth extends number> = {
 ```
 ```ts title="typescript"
 const flatten: <T, D extends number>(
-  arr: readonly T[],
-  depth?: D
+  arr: T[] | readonly T[],
+  depth?: D // default: 1
 ) => FlatArray<T[], D>[];
 ```
 

--- a/docs/docs/utils/array/flatten.md
+++ b/docs/docs/utils/array/flatten.md
@@ -1,0 +1,42 @@
+# flatten
+
+중첩 배열을 평탄화해주는 함수입니다.
+
+JS에서 기본적으로 제공하는 [flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)은 기본적으로 성능이 안좋습니다.
+
+해당 flatten 함수는 `js의 flat`과 `lodash의 flattenDepth`보다 성능적으로 우수합니다.
+
+![스크린샷 2024-07-05 오전 12 52 52](https://github.com/modern-agile-team/modern-kit/assets/64779472/ec47c879-6346-4f47-8ad1-006c00ce3d71)
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/flatten/index.ts)
+
+## Interface
+```ts title="typescript"
+type FlatArray<Arr, Depth extends number> = {
+    "done": Arr,
+    "recur": Arr extends ReadonlyArray<infer InnerArr>
+        ? FlatArray<InnerArr, [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20][Depth]>
+        : Arr
+}[Depth extends -1 ? "done" : "recur"];
+```
+```ts title="typescript"
+const flatten: <T, D extends number>(
+  arr: readonly T[],
+  depth?: D
+) => FlatArray<T[], D>[];
+```
+
+## Usage
+```ts title="typescript"
+import { flatten } from '@modern-kit/utils';
+
+const arr = [1, [2, [3, [4, [5]]]]];
+
+flatten(arr, 1); // [1, 2, [3, [4, [5]]]]
+flatten(arr, 2); // [1, 2, 3, [4, [5]]]
+flatten(arr, 3); // [1, 2, 3, 4, [5]]
+flatten(arr, 4); // [1, 2, 3, 4, 5]
+```

--- a/docs/docs/utils/array/flatten.md
+++ b/docs/docs/utils/array/flatten.md
@@ -2,9 +2,9 @@
 
 중첩 배열을 `평탄화`해주는 함수입니다. `depth` 옵션으로 평탄화 깊이를 직접 지정 할 수 있습니다.
 
-JS에서 기본적으로 제공하는 [flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)은 기본적으로 성능이 안좋습니다.
+JS에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)은 성능이 좋지 않습니다.
 
-해당 flatten 함수는 `js의 flat`과 `lodash의 flattenDepth`보다 성능적으로 우수합니다.
+제공하는 flatten 함수는 `JS의 flat`과 `lodash의 flattenDepth`보다 성능적으로 우수합니다.
 
 ![스크린샷 2024-07-05 오전 12 52 52](https://github.com/modern-agile-team/modern-kit/assets/64779472/ec47c879-6346-4f47-8ad1-006c00ce3d71)
 

--- a/packages/utils/src/array/flatten/flatten.spec.ts
+++ b/packages/utils/src/array/flatten/flatten.spec.ts
@@ -1,0 +1,60 @@
+import { flatten } from '.';
+
+describe('flatten', () => {
+  it('should flatten a deeply nested array to the specified depth', () => {
+    const arr = [1, [2, [3, [4, [5]]]]];
+
+    const result1 = flatten(arr, 1);
+    expect(result1).toEqual([1, 2, [3, [4, [5]]]]);
+    expectTypeOf(result1).toEqualTypeOf<
+      (number | (number | (number | number[])[])[])[]
+    >();
+
+    const result2 = flatten(arr, 2);
+    expect(result2).toEqual([1, 2, 3, [4, [5]]]);
+    expectTypeOf(result2).toEqualTypeOf<(number | (number | number[])[])[]>();
+
+    const result3 = flatten(arr, 3);
+    expect(result3).toEqual([1, 2, 3, 4, [5]]);
+    expectTypeOf(result3).toEqualTypeOf<(number | number[])[]>();
+
+    const result4 = flatten(arr, 4);
+    expect(result4).toEqual([1, 2, 3, 4, 5]);
+    expectTypeOf(result4).toEqualTypeOf<number[]>();
+  });
+
+  it('should return the same array if depth is 0 or NaN or negative', () => {
+    const arr = [1, [2, 3], [4, 5]];
+
+    const result1 = flatten(arr, 0);
+    expect(result1).toEqual([1, [2, 3], [4, 5]]);
+
+    const result2 = flatten(arr, NaN);
+    expect(result2).toEqual([1, [2, 3], [4, 5]]);
+
+    const result3 = flatten(arr, -1);
+    expect(result3).toEqual([1, [2, 3], [4, 5]]);
+  });
+
+  it('should handle empty arrays', () => {
+    const arr: any[] = [];
+    const result = flatten(arr, 1);
+    expect(result).toEqual([]);
+  });
+
+  it('should flatten a 2D array to the default depth of 1', () => {
+    const arr = [1, [2, 3], [4, 5]];
+    const result = flatten(arr);
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it('should handle arrays with mixed types', () => {
+    const arr = [1, 'a', [true, false, [null, undefined]]];
+
+    const result = flatten(arr, 2);
+    expect(result).toEqual([1, 'a', true, false, null, undefined]);
+    expectTypeOf(result).toEqualTypeOf<
+      (string | number | boolean | null | undefined)[]
+    >();
+  });
+});

--- a/packages/utils/src/array/flatten/index.ts
+++ b/packages/utils/src/array/flatten/index.ts
@@ -1,0 +1,19 @@
+export const flatten = <T, D extends number>(
+  arr: T[] | readonly T[],
+  depth = 1 as D
+) => {
+  const result = [] as FlatArray<T[], D>[];
+
+  const recursive = (arr: readonly T[], currentDepth: number) => {
+    for (const item of arr) {
+      if (Array.isArray(item) && currentDepth < depth) {
+        recursive(item, currentDepth + 1);
+      } else {
+        result.push(item as FlatArray<T[], D>);
+      }
+    }
+  };
+
+  recursive(arr, 0);
+  return result;
+};

--- a/packages/utils/src/array/index.ts
+++ b/packages/utils/src/array/index.ts
@@ -3,6 +3,7 @@ export * from './contains';
 export * from './countOccurrencesInArray';
 export * from './difference';
 export * from './excludeElements';
+export * from './flatten';
 export * from './intersection';
 export * from './intersectionWithDuplicates';
 export * from './partition';


### PR DESCRIPTION
## Overview

Issue: https://github.com/modern-agile-team/modern-kit/issues/302

중첩 배열을 `평탄화`해주는 함수입니다. `depth` 옵션으로 평탄화 깊이를 직접 지정 할 수 있습니다.

JS에서 기본적으로 제공하는 [flat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)은 기본적으로 성능이 안좋습니다.

해당 flatten 함수는 `js의 flat`과 `lodash의 flattenDepth`보다 성능적으로 우수합니다.

![스크린샷 2024-07-05 오전 12 52 52](https://github.com/modern-agile-team/modern-kit/assets/64779472/ec47c879-6346-4f47-8ad1-006c00ce3d71)

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)