### PR TITLE
fix(react): 컴포넌트 개선 Iterator, SeparatedIterator

### DIFF
--- a/.changeset/warm-falcons-sleep.md
+++ b/.changeset/warm-falcons-sleep.md
@@ -1,0 +1,7 @@
+---
+'@modern-kit/react': patch
+'@modern-kit/types': patch
+'@modern-kit/utils': patch
+---
+
+fix(react): 컴포넌트 개선 Iterator, SeparatedIterator - @ssi02014

--- a/docs/docs/react/components/Iterator.mdx
+++ b/docs/docs/react/components/Iterator.mdx
@@ -4,6 +4,8 @@ import { Iterator } from '@modern-kit/react';
 
 `items props`로 주어진 배열을 반복하면서, 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링할 수 있는 컴포넌트입니다.
 
+`itemKey`로 문자열을 넣으면, 각 요소에서 해당 프로퍼티 key의 값을 각 요소의 `unique key`로 설정합니다. 매칭되는 key가 없다면 배열 `index`를 기본 값으로 갖습니다.
+
 <br />
 
 ## Code
@@ -11,13 +13,15 @@ import { Iterator } from '@modern-kit/react';
 
 ## Interface
 ```ts title="typescript"
-interface IteratorProps<T> {
-  items: T[];
+export interface IteratorProps<T> {
+  items: T[] | readonly T[] | undefined;
+  itemKey?: string;
   renderItem: (item: T, index: number) => JSX.Element;
 }
 
-const Iterator: <T extends unknown>({
+const Iterator: <T>({
   items,
+  itemKey,
   renderItem,
 }: IteratorProps<T>) => JSX.Element;
 ```
@@ -40,6 +44,7 @@ const Example = () => {
 
   return (
     <Iterator
+      itemKey="id"
       items={items}
       renderItem={(item) => (
         <h3>
@@ -62,6 +67,7 @@ export const Example = () => {
 
   return (
     <Iterator
+      itemKey="id"
       items={items}
       renderItem={(item) => (
         <h3>

--- a/docs/docs/react/components/SeparatedIterator.mdx
+++ b/docs/docs/react/components/SeparatedIterator.mdx
@@ -2,9 +2,11 @@ import { SeparatedIterator } from '@modern-kit/react';
 
 # SeparatedIterator
 
-[Iterator](https://modern-agile-team.github.io/modern-kit/docs/react/components/Iterator)를 확장해 `items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 `Separator`를 렌더링 하는 컴포넌트입니다.
+[Iterator](https://modern-agile-team.github.io/modern-kit/docs/react/components/Iterator)를 확장해 `items props`로 주어진 배열을 반복하면서 각 항목에 대해 `특정 요소 및 컴포넌트`를 렌더링하며, 동시에 각 요소 사이에 `구분자(Separator)`를 렌더링 하는 컴포넌트입니다.
 
-기본적으로 마지막 요소 다음 `Separator`는 제외됩니다. `includeLastSeparator`를 `true`로 설정해서 포함시킬 수 있습니다.
+기본적으로 마지막 요소의 `Separator`는 제외됩니다. 하지만, `includeLastSeparator`를 `true`로 설정하면 포함시킬 수 있습니다.
+
+또한, `separatorInterval`를 활용해 특정 `간격` 만큼 Separator를 렌더링 할 수 있습니다.
 
 <br />
 
@@ -15,13 +17,16 @@ import { SeparatedIterator } from '@modern-kit/react';
 ```ts title="typescript"
 interface SeparatedIteratorProps<T> extends IteratorProps<T> {
   separator: JSX.Element;
-  includeLastSeparator?: boolean;
+  separatorInterval?: number; // default: 1
+  includeLastSeparator?: boolean; // default: false
 }
 
-const SeparatedIterator: <T extends unknown>({
+const SeparatedIterator: <T>({
+  itemKey,
   items,
-  renderItem,
   separator,
+  renderItem,
+  separatorInterval,
   includeLastSeparator,
 }: SeparatedIteratorProps<T>) => JSX.Element;
 ```

--- a/packages/react/src/components/Iterator/Iterator.spec.tsx
+++ b/packages/react/src/components/Iterator/Iterator.spec.tsx
@@ -21,6 +21,7 @@ describe('Iterator', () => {
   it('should render the correct number of items as div elements', () => {
     renderSetup(
       <Iterator
+        itemKey="id"
         items={testItems}
         renderItem={(item) => <div>{item.name}</div>}
       />
@@ -31,9 +32,31 @@ describe('Iterator', () => {
     expect(renderItems).toHaveLength(testItems.length);
   });
 
+  it('should not render any items when items prop is undefined', () => {
+    renderSetup(
+      <Iterator items={undefined} renderItem={() => <div>Item</div>} />
+    );
+
+    const renderItems = screen.queryAllByText(/Item/);
+    expect(renderItems).toHaveLength(0);
+  });
+
+  it('should render the correct number of items when items prop is an array of strings', () => {
+    renderSetup(
+      <Iterator
+        items={['Item 1', 'Item 2', 'Item 3']}
+        renderItem={(item) => <div>{item}</div>}
+      />
+    );
+
+    const renderItems = screen.getAllByText(/Item \d/);
+    expect(renderItems).toHaveLength(3);
+  });
+
   it('should render the correct number of items as TestComponent elements', () => {
     renderSetup(
       <Iterator
+        itemKey="id"
         items={testItems}
         renderItem={(item) => <TestComponent {...item} />}
       />

--- a/packages/react/src/components/Iterator/index.tsx
+++ b/packages/react/src/components/Iterator/index.tsx
@@ -1,19 +1,27 @@
-import { getUniqId } from '@modern-kit/utils';
-import React from 'react';
+import { isPlainObject } from '@modern-kit/utils';
+import React, { useCallback } from 'react';
 
 export interface IteratorProps<T> {
-  items: T[] | readonly T[];
+  items: T[] | readonly T[] | undefined;
+  itemKey?: string;
   renderItem: (item: T, index: number) => JSX.Element;
 }
 
-export const Iterator = <T extends unknown>({
-  items,
+export const Iterator = <T,>({
+  items = [],
+  itemKey = '',
   renderItem,
 }: IteratorProps<T>) => {
+  const getKey = useCallback(
+    (item: T, index: number) => {
+      return isPlainObject(item) ? item?.[itemKey] || index : index;
+    },
+    [itemKey]
+  );
   return (
     <>
       {items.map((item, index) => (
-        <React.Fragment key={getUniqId()}>
+        <React.Fragment key={getKey(item, index)}>
           {renderItem(item, index)}
         </React.Fragment>
       ))}

--- a/packages/react/src/components/SeparatedIterator/SeparatedIterator.spec.tsx
+++ b/packages/react/src/components/SeparatedIterator/SeparatedIterator.spec.tsx
@@ -30,6 +30,23 @@ describe('SeparatedIterator', () => {
     expect(separators).toHaveLength(testItems.length - 1);
   });
 
+  it('should render the correct number of items and separators at the specified interval', () => {
+    renderSetup(
+      <SeparatedIterator
+        items={testItems}
+        renderItem={(item) => <div>{item.name}</div>}
+        separatorInterval={2}
+        separator={<div>separator</div>}
+      />
+    );
+
+    const renderItems = screen.getAllByText(/Item \d/);
+    const separators = screen.getAllByText(/separator/);
+
+    expect(renderItems).toHaveLength(testItems.length);
+    expect(separators).toHaveLength(1);
+  });
+
   it('should render the correct number of separators when includeLastSeparator is true', () => {
     renderSetup(
       <SeparatedIterator
@@ -45,5 +62,22 @@ describe('SeparatedIterator', () => {
 
     expect(renderItems).toHaveLength(testItems.length);
     expect(separators).toHaveLength(testItems.length);
+  });
+
+  it('should not render any items when items prop is undefined', () => {
+    renderSetup(
+      <SeparatedIterator
+        items={undefined}
+        renderItem={() => <div>Item</div>}
+        separator={<div>separator</div>}
+        includeLastSeparator
+      />
+    );
+
+    const renderItems = screen.queryAllByText(/Item \d/);
+    const separators = screen.queryAllByText(/separator/);
+
+    expect(renderItems).toHaveLength(0);
+    expect(separators).toHaveLength(0);
   });
 });

--- a/packages/react/src/components/SeparatedIterator/index.tsx
+++ b/packages/react/src/components/SeparatedIterator/index.tsx
@@ -1,23 +1,38 @@
+import { useCallback } from 'react';
 import { Iterator, IteratorProps } from '../Iterator';
 
 interface SeparatedIteratorProps<T> extends IteratorProps<T> {
   separator: JSX.Element;
+  separatorInterval?: number;
   includeLastSeparator?: boolean;
 }
 
-export const SeparatedIterator = <T extends unknown>({
-  items,
-  renderItem,
+export const SeparatedIterator = <T,>({
+  itemKey,
+  items = [],
   separator,
+  renderItem,
+  separatorInterval = 1,
   includeLastSeparator = false,
 }: SeparatedIteratorProps<T>) => {
+  const isRenderSeparator = useCallback(
+    (index: number) => {
+      if (index === items.length - 1) {
+        return includeLastSeparator;
+      }
+      return (index + 1) % separatorInterval === 0;
+    },
+    [includeLastSeparator, separatorInterval, items.length]
+  );
+
   return (
     <Iterator
       items={items}
+      itemKey={itemKey}
       renderItem={(item, index) => (
         <>
           {renderItem(item, index)}
-          {(includeLastSeparator || index < items.length - 1) && separator}
+          {isRenderSeparator(index) && separator}
         </>
       )}
     />

--- a/packages/types/src/Reference/index.ts
+++ b/packages/types/src/Reference/index.ts
@@ -1,5 +1,5 @@
 export type Reference =
-  | object
+  | Record<PropertyKey, any>
   | any[]
   | Function
   | Set<any>

--- a/packages/utils/src/validator/isPlainObject/index.ts
+++ b/packages/utils/src/validator/isPlainObject/index.ts
@@ -1,5 +1,7 @@
 import { isReference } from '../isReference';
 
-export const isPlainObject = (value: unknown): value is object => {
+export const isPlainObject = (
+  value: unknown
+): value is Record<PropertyKey, any> => {
   return isReference(value) && value.constructor === Object;
 };

--- a/packages/utils/src/validator/isReference/index.ts
+++ b/packages/utils/src/validator/isReference/index.ts
@@ -1,6 +1,7 @@
-import { Reference } from '@modern-kit/types';
 import { isPrimitive } from '../isPrimitive';
 
-export const isReference = (value: unknown): value is Reference => {
+export const isReference = (
+  value: unknown
+): value is Record<PropertyKey, any> => {
   return !isPrimitive(value);
 };


### PR DESCRIPTION
## Overview

Iterator는 Fragment에 매번 uniqueKey를 할당하는건 적절하지 않습니다. 따라서, itemKey props를 활용해 이를 지정 할 수 있게 합니다. 만약 매칭되는게 없다면 Index를 key로 갖습니다.

SeparatedIterator는 seperatorInterval 값을 갖습니다. 이를 통해 특정 간격 만큼 separator를 렌더링 할 수 있습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)