### PR TITLE
fix(utils): intersection 기능 개선 및 밴치마크 추가

### DIFF
--- a/docs/docs/utils/array/intersection.md
+++ b/docs/docs/utils/array/intersection.md
@@ -4,12 +4,24 @@
 
 기본적으로 `원시 값`에 대해서만 중복 요소를 판단하며, 필요 시 3번째 인자인 `iteratee` 함수 결과로 교차되는 요소임을 판단할 수 있습니다.
 
-위 함수는 첫번째 배열을 기준으로 중복된 값을 제거합니다.
+위 함수는 첫번째 배열을 기준으로 `중복된 값을 제거`합니다.
 
 <br />
 
 ## Code
 [🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/intersection/index.ts)
+
+## Benchmark
+- `hz`: 초당 작업 수
+- `mean`: 평균 응답 시간(ms)
+
+|이름|hz|mean|성능|
+|------|---|---|---|
+|modern-kit/intersection|349,708.54|0.0002|`fastest`|
+|lodash/intersectionBy|163,209.81|0.0002|`slowest`|
+
+- **modern-kit/intersection**
+  - `2.14x` faster than lodash/intersectionBy
 
 ## Interface
 ```ts title="typescript"

--- a/docs/docs/utils/array/intersection.md
+++ b/docs/docs/utils/array/intersection.md
@@ -17,11 +17,11 @@
 
 |이름|hz|mean|성능|
 |------|---|---|---|
-|modern-kit/intersection|349,708.54|0.0002|`fastest`|
-|lodash/intersectionBy|163,209.81|0.0002|`slowest`|
+|modern-kit/intersection|338,190.49|0.0030|`fastest`|
+|lodash/intersectionBy|159,624.82|0.0063|`slowest`|
 
 - **modern-kit/intersection**
-  - `2.14x` faster than lodash/intersectionBy
+  - `2.12x` faster than lodash/intersectionBy
 
 ## Interface
 ```ts title="typescript"

--- a/packages/utils/src/array/intersection/index.ts
+++ b/packages/utils/src/array/intersection/index.ts
@@ -1,16 +1,14 @@
-import { identity } from '../../common';
-
 import { intersectionWithDuplicates, uniq } from '..';
 
-export const intersection = <T, U = T>(
+export const intersection = <T, U>(
   firstArr: T[] | readonly T[],
   secondArr: T[] | readonly T[],
-  iteratee: (item: T) => T | U = identity,
+  iteratee?: (item: T) => U
 ) => {
   const intersection = intersectionWithDuplicates(
     firstArr,
     secondArr,
-    iteratee,
+    iteratee
   );
 
   return uniq(intersection, iteratee);

--- a/packages/utils/src/array/intersection/intersection.bench.ts
+++ b/packages/utils/src/array/intersection/intersection.bench.ts
@@ -1,0 +1,22 @@
+import { bench, describe } from 'vitest';
+import { intersectionBy as intersectionByLodash } from 'lodash-es';
+import { intersection } from '.';
+
+const createTestArr = () => {
+  return Array.from({ length: 50 }, () => ({
+    id: Math.floor(Math.random() * 10),
+  }));
+};
+
+describe('intersection', () => {
+  const arr1 = createTestArr();
+  const arr2 = createTestArr();
+
+  bench('modern-kit/intersection', () => {
+    intersection(arr1, arr2, (item) => item.id);
+  });
+
+  bench('lodash/intersectionBy', () => {
+    intersectionByLodash(arr1, arr2, 'id');
+  });
+});

--- a/packages/utils/src/array/intersectionWithDuplicates/index.ts
+++ b/packages/utils/src/array/intersectionWithDuplicates/index.ts
@@ -1,13 +1,15 @@
-import { identity } from '../../common';
-
-export const intersectionWithDuplicates = <T, U = T>(
+export const intersectionWithDuplicates = <T, U>(
   firstArr: T[] | readonly T[],
   secondArr: T[] | readonly T[],
-  iteratee: (item: T) => T | U = identity,
+  iteratee?: (item: T) => U
 ) => {
-  const secondArrSetAppliedIteratee = new Set(secondArr.map(iteratee));
-
-  return firstArr.filter((item) =>
-    secondArrSetAppliedIteratee.has(iteratee(item)),
+  const secondArrToSet = new Set<T | U>(
+    iteratee ? secondArr.map(iteratee) : secondArr
   );
+
+  const filterFn = iteratee
+    ? (element: T) => secondArrToSet.has(iteratee(element))
+    : (element: T) => secondArrToSet.has(element);
+
+  return firstArr.filter(filterFn);
 };

--- a/packages/utils/vitest.config.ts
+++ b/packages/utils/vitest.config.ts
@@ -11,7 +11,12 @@ export default defineConfig({
     globals: true,
     coverage: {
       provider: 'istanbul',
-      exclude: ['src/storage', 'src/clipboard', 'src/file'],
+      exclude: [
+        'src/storage',
+        'src/clipboard',
+        'src/file',
+        'src/**/*.bench.ts',
+      ],
     },
   },
 });


### PR DESCRIPTION
## Overview

fix(utils): intersection 기능 개선 및 밴치마크 추가

intersectionWithDuplicates 는 비교 대상이 없어 밴치마크 테스트 제외

### benchmark
- lodash의 intersectionBy보다  평균적으로 `약 2배` 더 빠릅니다.

<img width="898" alt="스크린샷 2024-07-07 오후 5 48 42" src="https://github.com/modern-agile-team/modern-kit/assets/64779472/ebd021e7-6047-4686-a1bd-ecccc9f5d5d5">

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)