### PR TITLE
feat(utils): flattenDeep 함수 추가

### DIFF
--- a/.changeset/tricky-crabs-clap.md
+++ b/.changeset/tricky-crabs-clap.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): flattenDeep 함수 추가 - @ssi02014

--- a/docs/docs/utils/array/flatten.md
+++ b/docs/docs/utils/array/flatten.md
@@ -17,13 +17,13 @@ JS에서 기본적으로 제공하는 [Array.prototype.flat](https://developer.m
 
 |이름|hz|mean|성능|
 |------|---|---|---|
-|modern-kit/flatten|5,819,693.59|0.0002|`fastest`|
-|lodash/flattenDepth|4,023,776.90|0.0002|-|
-|js built-in/flat|831,811.86|0.0012|`slowest`|
+|modern-kit/flatten|2,303,725.15|0.0004|`fastest`|
+|lodash/flattenDepth|1,546,277.36|0.0006|-|
+|js built-in/flat|346,378.13|0.0029|`slowest`|
 
 - **modern-kit/flatten**
-  - `1.34x` faster than lodash/flattenDepth
-  - `6.50x` faster than js built-in/flat
+  - `1.49x` faster than lodash/flattenDepth
+  - `6.65x` faster than js built-in/flat
 
 ## Interface
 ```ts title="typescript"

--- a/docs/docs/utils/array/flattenDeep.md
+++ b/docs/docs/utils/array/flattenDeep.md
@@ -1,0 +1,61 @@
+# flattenDeep
+
+**[flatten](https://modern-agile-team.github.io/modern-kit/docs/utils/array/flatten)** 을 기반으로 `모든 깊이의 중첩 배열`을 `평탄화`해주는 함수입니다.
+
+JS의 **[Array.prototype.flat(Infinity)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)** 와 비교했을 때 `성능면에서 우수`하며, 더욱 `정확한 타입 추론`을 할 수 있습니다.
+
+```ts title="typescript"
+// as-is 
+// Array.prototype.flat(Infinity)
+const arr = [1, [2, [3]]].flat(Infinity);
+/*
+ * const arr: FlatArray<number | (number | number[])[], 0 | 1 | 2 | 3 | -1 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20>[]
+ */
+```
+```ts title="typescript"
+// to-be 
+// flattenDeep
+const arr = flattenDeep([1, [2, [3]]]);
+/*
+ * const arr: number[]
+ */
+```
+
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/flattenDeep/index.ts)
+
+## Benchmark
+- `hz`: 초당 작업 수
+- `mean`: 평균 응답 시간(ms)
+
+|이름|hz|mean|성능|
+|------|---|---|---|
+|modern-kit/flattenDeep|2,028,846.09|0.0005|`fastest`|
+|lodash/flattenDeep|1,481,161.98|0.0007|-|
+|js built-in/flat(Infinity)|340,193.06|0.0029|`slowest`|
+
+- **modern-kit/flattenDeep**
+  - `1.40x` faster than lodash/flattenDeep
+  - `5.99x` faster than js built-in/flat(Infinity)
+
+## Interface
+```ts title="typescript"
+// 중첩된 배열 타입을 재귀적으로 풀어내어 가장 내부의 요소 타입을 추출하는 유틸리티 타입
+// type Example = ExtractNestedArrayType<(number | (number | number[])[])[]> // Example: number
+type ExtractNestedArrayType<T> = T extends readonly (infer U)[] ? ExtractNestedArrayType<U> : T;
+```
+```ts title="typescript"
+const flattenDeep: <T>(arr: T[] | readonly T[]) => ExtractNestedArrayType<T>[]
+```
+
+## Usage
+```ts title="typescript"
+import { flattenDeep } from '@modern-kit/utils';
+
+const arr = [1, [2, [3, [4, [5]]]]];
+
+flattenDeep(arr); // [1, 2, 3, 4, 5]
+```

--- a/packages/utils/src/array/flattenDeep/flattenDeep.bench.ts
+++ b/packages/utils/src/array/flattenDeep/flattenDeep.bench.ts
@@ -1,6 +1,6 @@
 import { bench, describe } from 'vitest';
-import { flattenDepth as flattenDepthLodash } from 'lodash-es';
-import { flatten } from '.';
+import { flattenDeep as flattenDeepLodash } from 'lodash-es';
+import { flattenDeep } from '.';
 
 const createNestedArray = (values: any[]) => {
   if (values.length === 0) {
@@ -10,20 +10,20 @@ const createNestedArray = (values: any[]) => {
   return [first, createNestedArray(rest)];
 };
 
-describe('flatten', () => {
+describe('flattenDeep', () => {
   const arr = createNestedArray(
     Array.from({ length: 30 }, (_, index) => index)
   );
 
-  bench('modern-kit/flatten', () => {
-    flatten(arr, 30);
+  bench('modern-kit/flattenDeep', () => {
+    flattenDeep(arr);
   });
 
-  bench('lodash/flattenDepth', () => {
-    flattenDepthLodash(arr, 30);
+  bench('lodash/flattenDeep', () => {
+    flattenDeepLodash(arr);
   });
 
-  bench('js built-in/flat', () => {
-    arr.flat(30);
+  bench('js built-in/flat(Infinity)', () => {
+    arr.flat(Infinity);
   });
 });

--- a/packages/utils/src/array/flattenDeep/flattenDeep.spec.ts
+++ b/packages/utils/src/array/flattenDeep/flattenDeep.spec.ts
@@ -1,0 +1,21 @@
+import { flattenDeep } from '.';
+
+describe('flatten', () => {
+  it('should flatten a deeply nested array of numbers', () => {
+    const arr = [1, [2, [3, [4, [5]]]]];
+    const flattenedArray = flattenDeep(arr);
+
+    expect(flattenedArray).toEqual([1, 2, 3, 4, 5]);
+    expectTypeOf(flattenedArray).toEqualTypeOf<number[]>();
+  });
+
+  it('should flatten a deeply nested array with mixed types', () => {
+    const arr = [1, ['str', [3, [4, [false, [{ id: 1 }]]]]]];
+    const flattenedArray = flattenDeep(arr);
+
+    expect(flattenedArray).toEqual([1, 'str', 3, 4, false, { id: 1 }]);
+    expectTypeOf(flattenedArray).toEqualTypeOf<
+      (string | number | boolean | { id: number })[]
+    >();
+  });
+});

--- a/packages/utils/src/array/flattenDeep/index.ts
+++ b/packages/utils/src/array/flattenDeep/index.ts
@@ -1,0 +1,6 @@
+import { ExtractNestedArrayType } from '@modern-kit/types';
+import { flatten } from '../../array';
+
+export const flattenDeep = <T>(arr: T[] | readonly T[]) => {
+  return flatten(arr, Infinity) as ExtractNestedArrayType<T>[];
+};


### PR DESCRIPTION
## Overview

Issue: #307 

기존에 생성된 flatten 을 기반으로 `모든 깊이의 중첩 배열`을 `평탄화`해주는 함수입니다.

JS의 **[Array.prototype.flat(Infinity)](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat)** 와 비교했을 때 `성능면에서 우수`하며, 더욱 `정확한 타입 추론`을 할 수 있습니다.

```ts title="typescript"
// as-is 
// Array.prototype.flat(Infinity)
const arr = [1, [2, [3]]].flat(Infinity);
/*
 * const arr: FlatArray<number | (number | number[])[], 0 | 1 | 2 | 3 | -1 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20>[]
 */
```
```ts title="typescript"
// to-be 
// flattenDeep
const arr = flattenDeep([1, [2, [3]]]);
/*
 * const arr: number[]
 */
```


## Benchmark
- lodash의 flattenDeep 보다 약 `1.4배` 빠름
- flat(Infinity)보다 약 `6배` 빠름
![스크린샷 2024-07-08 오후 6 52 48](https://github.com/modern-agile-team/modern-kit/assets/64779472/8a24d370-3365-469c-a11e-f6d3af7e84ea)

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)