### PR TITLE
feat(utils): size 신규 유틸 함수 추가

### DIFF
--- a/.changeset/rotten-emus-thank.md
+++ b/.changeset/rotten-emus-thank.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): size 신규 유틸 함수 추가 - @ssi02014

--- a/docs/docs/utils/common/size.md
+++ b/docs/docs/utils/common/size.md
@@ -1,0 +1,41 @@
+# size
+
+주어진 값의 크기를 반환합니다. 크기는 값의 유형에 따라 결정됩니다:
+  - `문자열`의 경우, 문자 수를 반환합니다.
+  - `배열`, `NodeList` 및 `HTMLCollection`의 경우, 요소의 수를 반환합니다.
+  - `Se`t 및 `Map`의 경우, 항목 수를 반환합니다.
+  - 일반 객체의 경우, `자체 열거 가능한 속성의 수`를 반환합니다.
+  - 그 외 숫자, WeakMap, WeakSet 등의 타입은 허용하지 않습니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/common/size/index.ts)
+
+## Benchmark
+- `hz`: 초당 작업 수
+- `mean`: 평균 응답 시간(ms)
+
+|이름|hz|mean|성능|
+|------|---|---|---|
+|modern-kit/size|868,075.34|0.0012|`fastest`|
+|lodash/size|232,384.63|0.0043|`slowest`|
+
+- **modern-kit/size**
+  - `3.74x` faster than lodash/size
+
+## Interface
+```ts title="typescript"
+function size(value: string | Record<PropertyKey, any>): number
+```
+
+## Usage
+```ts
+size('12345'); // 5
+
+size([1, 2, 3, 4, 5]); // 5
+
+size(new Set([1, 2, 3, 4, 5])); // 5
+
+size({ a: 1, b: 2, c: 3, d: 4, e: 5 }); // 5
+```

--- a/packages/utils/src/common/size/index.ts
+++ b/packages/utils/src/common/size/index.ts
@@ -1,0 +1,47 @@
+import { isArray, isPlainObject, isString } from '../../validator';
+
+/**
+ * @description 주어진 값의 크기를 반환합니다. 크기는 값의 유형에 따라 결정됩니다:
+ * - 문자열의 경우, 문자 수를 반환합니다.
+ * - 배열, NodeList 및 HTMLCollection의 경우, 요소의 수를 반환합니다.
+ * - Set 및 Map의 경우, 항목 수를 반환합니다.
+ * - 일반 객체의 경우, 자체 열거 가능한 속성의 수를 반환합니다.
+ * - 그 외 숫자, WeakMap, WeakSet 등의 타입은 허용하지 않습니다.
+ *
+ * @param {string | Record<PropertyKey, any>} value - 크기를 결정할 값입니다. 문자열, 배열, NodeList, HTMLCollection, Set, Map 또는 일반 객체일 수 있습니다.
+ * @returns {number} 주어진 값의 크기입니다.
+ * @throws {Error} 값의 유형이 유효하지 않은 경우 오류를 발생시킵니다.
+ *
+ * @example
+ * size('12345');
+ * // 5
+ *
+ * size([1, 2, 3, 4, 5]);
+ * // 5
+ *
+ * size({ a: 1, b: 2, c: 3, d: 4, e: 5 });
+ * // 5
+ */
+export function size(value: string | Record<PropertyKey, any>): number {
+  if (isString(value)) {
+    return value.length;
+  }
+
+  if (
+    isArray(value) ||
+    value instanceof NodeList ||
+    value instanceof HTMLCollection
+  ) {
+    return value.length;
+  }
+
+  if (value instanceof Set || value instanceof Map) {
+    return value.size;
+  }
+
+  if (isPlainObject(value)) {
+    return Object.keys(value).length;
+  }
+
+  throw new Error('Invalid value');
+}

--- a/packages/utils/src/common/size/size.bench.ts
+++ b/packages/utils/src/common/size/size.bench.ts
@@ -1,0 +1,19 @@
+import { bench, describe } from 'vitest';
+import { size as sizeLodash } from 'lodash-es';
+import { size } from '.';
+
+describe('size', () => {
+  bench('modern-kit/size', () => {
+    size('12345');
+    size([1, 2, 3, 4, 5]);
+    size(new Set([1, 2, 3, 4, 5]));
+    size({ a: 1, b: 2, c: 3, d: 4, e: 5 });
+  });
+
+  bench('lodash/size', () => {
+    sizeLodash('12345');
+    sizeLodash([1, 2, 3, 4, 5]);
+    sizeLodash(new Set([1, 2, 3, 4, 5]));
+    sizeLodash({ a: 1, b: 2, c: 3, d: 4, e: 5 });
+  });
+});

--- a/packages/utils/src/common/size/size.spec.ts
+++ b/packages/utils/src/common/size/size.spec.ts
@@ -1,0 +1,51 @@
+import { size } from '.';
+
+describe('size function', () => {
+  it('should return the length of a string', () => {
+    expect(size('foo')).toBe(3);
+  });
+
+  it('should return the length of a array', () => {
+    expect(size([1, 2, 3])).toBe(3);
+  });
+
+  it('should return the size of a Set', () => {
+    const set = new Set([1, 2, 3]);
+    expect(size(set)).toBe(3);
+  });
+
+  it('should return the size of a Map', () => {
+    const map = new Map([
+      ['a', 1],
+      ['b', 2],
+    ]);
+    expect(size(map)).toBe(2);
+  });
+
+  it('should return the length of a NodeList', () => {
+    document.body.innerHTML = '<div></div><div></div><div></div>';
+
+    const nodeList = document.querySelectorAll('div');
+    expect(size(nodeList)).toBe(3);
+  });
+
+  it('should return the length of an HTMLCollection', () => {
+    document.body.innerHTML = '<div></div><div></div><div></div>';
+
+    const htmlCollection = document.getElementsByTagName('div');
+    expect(size(htmlCollection)).toBe(3);
+  });
+
+  it('should return the number of keys in a plain object', () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    expect(size(obj)).toBe(3);
+  });
+
+  it('should throw an error for invalid values', () => {
+    expect(() => size(123 as any)).toThrow('Invalid value');
+    expect(() => size(null as any)).toThrow('Invalid value');
+    expect(() => size(undefined as any)).toThrow('Invalid value');
+    expect(() => size(new WeakMap())).toThrow('Invalid value');
+    expect(() => size(new WeakSet())).toThrow('Invalid value');
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #334 

주어진 값의 크기를 반환합니다. 크기는 값의 유형에 따라 결정됩니다:
 - 문자열의 경우, 문자 수를 반환합니다.
 - 배열, NodeList 및 HTMLCollection의 경우, 요소의 수를 반환합니다.
 - Set 및 Map의 경우, 항목 수를 반환합니다.
 - 일반 객체의 경우, 자체 열거 가능한 속성의 수를 반환합니다.
 - 그 외 숫자, WeakMap, WeakSet 등의 타입은 허용하지 않습니다.

### benchmark
<img width="847" alt="스크린샷 2024-07-14 오후 4 43 52" src="https://github.com/user-attachments/assets/78c93650-a44b-4a35-8f39-ad6d6ee2f739">

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)