### PR TITLE
feat(utils): shuffle 신규 함수 추가

### DIFF
--- a/.changeset/twenty-bats-leave.md
+++ b/.changeset/twenty-bats-leave.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): shuffle 신규 함수 추가 - @ssi02014

--- a/docs/docs/utils/array/shuffle.md
+++ b/docs/docs/utils/array/shuffle.md
@@ -1,0 +1,33 @@
+# shuffle
+
+배열의 요소들의 순서를 무작위로 섞습니다.
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/array/shuffle/index.ts)
+
+## Benchmark
+- `hz`: 초당 작업 수
+- `mean`: 평균 응답 시간(ms)
+
+|이름|hz|mean|성능|
+|------|---|---|---|
+|modern-kit/shuffle|2,874,351.45|0.0003|`fastest`|
+|lodash/shuffle|1,895,677.79|0.0005|`slowest`|
+
+- **modern-kit/shuffle**
+  - `1.52x` faster than lodash/shuffle
+
+## Interface
+
+```ts title="typescript"
+function shuffle<T>(arr: T[] | readonly T[]): T[]
+```
+
+## Usage
+
+```ts title="typescript"
+import { shuffle } from '@modern-kit/utils';
+
+shuffle([1, 2, 3, 4, 5]); // 무작위로 섞인 배열이 반환됩니다. ex: [3, 5, 1, 3, 2]
+```
+

--- a/packages/utils/src/array/index.ts
+++ b/packages/utils/src/array/index.ts
@@ -10,5 +10,6 @@ export * from './forEachRight';
 export * from './intersection';
 export * from './intersectionWithDuplicates';
 export * from './partition';
+export * from './shuffle';
 export * from './union';
 export * from './uniq';

--- a/packages/utils/src/array/shuffle/index.ts
+++ b/packages/utils/src/array/shuffle/index.ts
@@ -1,0 +1,29 @@
+const swap = <T>(arr: T[], i: number, j: number) => {
+  [arr[i], arr[j]] = [arr[j], arr[i]];
+};
+
+/**
+ * @description 배열의 요소들의 순서를 무작위로 섞습니다.
+ *
+ * https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+ * Fisher–Yates shuffle의 현대 알고리즘을 기반으로 구현됐습니다.
+ *
+ * @param arr - 셔플할 배열입니다.
+ * @returns 순서가 무작위로 섞인 새로운 배열입니다.
+ *
+ * @example
+ * const array = [1, 2, 3, 4, 5];
+ * shuffle(array);
+ * // 순서가 무작위로 섞인 배열 ex. [3, 1, 4, 5, 2]
+ */
+export function shuffle<T>(arr: T[] | readonly T[]) {
+  const result = arr.slice();
+
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+
+    swap(result, i, j);
+  }
+
+  return result;
+}

--- a/packages/utils/src/array/shuffle/shuffle.bench.ts
+++ b/packages/utils/src/array/shuffle/shuffle.bench.ts
@@ -1,0 +1,15 @@
+import { bench, describe } from 'vitest';
+import { shuffle as shuffleLodash } from 'lodash-es';
+import { shuffle } from '.';
+
+describe('shuffle', () => {
+  const arr = Array.from({ length: 30 }, (_, index) => index);
+
+  bench('modern-kit/shuffle', () => {
+    shuffle(arr);
+  });
+
+  bench('lodash/shuffle', () => {
+    shuffleLodash(arr);
+  });
+});

--- a/packages/utils/src/array/shuffle/shuffle.spec.ts
+++ b/packages/utils/src/array/shuffle/shuffle.spec.ts
@@ -1,0 +1,17 @@
+import { shuffle } from '.';
+
+describe('shuffle', () => {
+  it('should shuffle an array of numbers', () => {
+    const arr = [1, 2, 3, 4, 5];
+
+    expect(shuffle(arr).slice().sort()).toEqual(arr.slice().sort());
+  });
+
+  it('should not modify the original array', () => {
+    const arr = [1, 2, 3, 4, 5];
+    const copiedArr = arr.slice();
+
+    shuffle(arr);
+    expect(arr).toEqual(copiedArr);
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #335 

배열 요소의 위치를 무작위로 변경해주는 shuffle 함수를 추가합니다.
[Fisher–Yates shuffle의 현대 알고리즘](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm)을 기반으로 구현됐습니다.

### benchmark
- lodash보다 약 1.5배 더 빠릅니다.
![스크린샷 2024-07-15 오후 8 13 46](https://github.com/user-attachments/assets/b099eab8-87b1-4cbe-a184-f9197155ef9e)


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)