### PR TITLE
feat(utils) mapValues 유틸 함수 추가

### DIFF
--- a/.changeset/happy-cats-wave.md
+++ b/.changeset/happy-cats-wave.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): mapValues 유틸 함수 추가 - @Gaic4o

--- a/docs/docs/utils/object/mapValues.md
+++ b/docs/docs/utils/object/mapValues.md
@@ -1,0 +1,48 @@
+# mapValues
+
+주어진 객체의 각 값에 대해 제공된 `변환 함수`를 호출하여 새 객체를 생성하는 함수입니다. 반환된 객체는 원본 객체의 값들을 복사하여 변환한 후 생성된 새로운 객체입니다.
+
+## Code
+
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/object/mapValues/index.ts)
+
+## Benchmark
+
+- `hz`: 초당 작업 수
+- `mean`: 평균 응답 시간(ms)
+
+|이름|hz|mean|성능|
+|------|---|---|---|
+|modern-kit/mapValues|7,168,899,49|0.0001|`fastest`|
+|lodash/mapValues|3,676,343,30|0.0003|`slowest`|
+
+- **modern-kit/mapValues**
+  - `1.95x` faster than lodash/mapValues
+
+
+## Interface
+
+```ts title="typescript"
+const mapValues: <T, R>(
+  object: Record<string | number, T>,
+  iteratee: (iterateData: {
+    key: string | number;
+    value: T;
+    object: Record<string | number, T>;
+  }) => R
+) => Record<string | number, R>
+```
+
+## Usage
+
+```ts title="typescript"
+import { mapValues } from '@modern-kit/utils';
+
+const users = {
+  fred: { user: 'fred', age: 40 },
+  pebbles: { user: 'pebbles', age: 1 }
+};
+
+const newUsers = mapValues(users, ({ value }) => value.age);
+// { fred: 40, pebbles: 1 }
+```

--- a/docs/docs/utils/object/mapValues.md
+++ b/docs/docs/utils/object/mapValues.md
@@ -6,31 +6,13 @@
 
 [🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/object/mapValues/index.ts)
 
-## Benchmark
-
-- `hz`: 초당 작업 수
-- `mean`: 평균 응답 시간(ms)
-
-|이름|hz|mean|성능|
-|------|---|---|---|
-|modern-kit/mapValues|7,168,899,49|0.0001|`fastest`|
-|lodash/mapValues|3,676,343,30|0.0003|`slowest`|
-
-- **modern-kit/mapValues**
-  - `1.95x` faster than lodash/mapValues
-
-
 ## Interface
 
 ```ts title="typescript"
-const mapValues: <T, R>(
-  object: Record<string | number, T>,
-  iteratee: (iterateData: {
-    key: string | number;
-    value: T;
-    object: Record<string | number, T>;
-  }) => R
-) => Record<string | number, R>
+function mapValues<T extends Record<PropertyKey, any>, V>(
+  object: T,
+  iteratee: (iterateData: { key: keyof T; value: T[keyof T]; object: T }) => V
+): Record<keyof T, V>
 ```
 
 ## Usage

--- a/packages/utils/src/object/index.ts
+++ b/packages/utils/src/object/index.ts
@@ -1,5 +1,6 @@
 export * from './deleteFalsyProperties';
 export * from './invert';
+export * from './mapValues';
 export * from './mergeProperties';
 export * from './objectEntries';
 export * from './objectKeys';

--- a/packages/utils/src/object/mapValues/index.ts
+++ b/packages/utils/src/object/mapValues/index.ts
@@ -1,27 +1,24 @@
+import { hasProperty } from '../../validator';
 /**
  * @description 주어진 객체의 각 값에 대해 제공된 변환 함수를 호출하여 새 객체를 생성하는 함수입니다.
  *
  * @template T - 원본 객체 값의 유형입니다.
  * @template R - 반환할 새 객체 값의 유형입니다.
- * @param {Record<string | number, T>} object - 순회할 원본 객체입니다.
- * @param {(iterateData: { key: string | number; value: T; object: Record<string | number, T> }) => R} iteratee - 객체의 각 값에 대해 호출할 변환 함수입니다.
- * @returns {Record<string | number, R>} 변환 함수의 결과를 포함하는 새 객체를 반환합니다.
+ * @param {T} object - 순회할 원본 객체입니다.
+ * @param {(iterateData: { key: keyof T; value: T[keyof T]; object: T }) => V} iteratee - 객체의 각 값에 대해 호출할 변환 함수입니다.
+ * @returns {Record<keyof T, V>} 변환 함수의 결과를 포함하는 새 객체를 반환합니다.
  */
-export const mapValues = <T, R>(
-  object: Record<string | number, T>,
-  iteratee: (iterateData: {
-    key: string | number;
-    value: T;
-    object: Record<string | number, T>;
-  }) => R
-): Record<string | number, R> => {
-  const result = {} as Record<string | number, R>;
+export function mapValues<T extends Record<PropertyKey, any>, V>(
+  object: T,
+  iteratee: (iterateData: { key: keyof T; value: T[keyof T]; object: T }) => V
+): Record<keyof T, V> {
+  const result = {} as Record<keyof T, V>;
 
   for (const key in object) {
-    if (Object.prototype.hasOwnProperty.call(object, key)) {
+    if (hasProperty(object, key)) {
       result[key] = iteratee({ key, value: object[key], object });
     }
   }
 
   return result;
-};
+}

--- a/packages/utils/src/object/mapValues/index.ts
+++ b/packages/utils/src/object/mapValues/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @description 주어진 객체의 각 값에 대해 제공된 변환 함수를 호출하여 새 객체를 생성하는 함수입니다.
+ *
+ * @template T - 원본 객체 값의 유형입니다.
+ * @template R - 반환할 새 객체 값의 유형입니다.
+ * @param {Record<string | number, T>} object - 순회할 원본 객체입니다.
+ * @param {(iterateData: { key: string | number; value: T; object: Record<string | number, T> }) => R} iteratee - 객체의 각 값에 대해 호출할 변환 함수입니다.
+ * @returns {Record<string | number, R>} 변환 함수의 결과를 포함하는 새 객체를 반환합니다.
+ */
+export const mapValues = <T, R>(
+  object: Record<string | number, T>,
+  iteratee: (iterateData: {
+    key: string | number;
+    value: T;
+    object: Record<string | number, T>;
+  }) => R
+): Record<string | number, R> => {
+  const result = {} as Record<string | number, R>;
+
+  for (const key in object) {
+    if (Object.prototype.hasOwnProperty.call(object, key)) {
+      result[key] = iteratee({ key, value: object[key], object });
+    }
+  }
+
+  return result;
+};

--- a/packages/utils/src/object/mapValues/index.ts
+++ b/packages/utils/src/object/mapValues/index.ts
@@ -1,4 +1,5 @@
 import { hasProperty } from '../../validator';
+
 /**
  * @description 주어진 객체의 각 값에 대해 제공된 변환 함수를 호출하여 새 객체를 생성하는 함수입니다.
  *

--- a/packages/utils/src/object/mapValues/mapValues.bench.ts
+++ b/packages/utils/src/object/mapValues/mapValues.bench.ts
@@ -19,7 +19,7 @@ describe('mapValues', () => {
     mapValues(obj, iteratee);
   });
 
-  bench('lodash mapValues', () => {
+  bench('lodash/mapValues', () => {
     mapValuesLodash(obj, iteratee);
   });
 });

--- a/packages/utils/src/object/mapValues/mapValues.bench.ts
+++ b/packages/utils/src/object/mapValues/mapValues.bench.ts
@@ -1,0 +1,29 @@
+import { bench, describe } from 'vitest';
+import { mapValues as mapValuesLodash } from 'lodash-es';
+import { mapValues } from '.';
+describe('mapValues', () => {
+  const obj = {
+    a: 1,
+    b: 2,
+    c: 3,
+    d: 4,
+    e: 5,
+    f: 6,
+    g: 7,
+  };
+
+  const iteratee = ({
+    value,
+  }: {
+    key: string | number;
+    value: number;
+  }): number => value;
+
+  bench('modern-kit/mapValues', () => {
+    mapValues(obj, iteratee);
+  });
+
+  bench('lodash mapValues', () => {
+    mapValuesLodash(obj, iteratee);
+  });
+});

--- a/packages/utils/src/object/mapValues/mapValues.bench.ts
+++ b/packages/utils/src/object/mapValues/mapValues.bench.ts
@@ -12,12 +12,8 @@ describe('mapValues', () => {
     g: 7,
   };
 
-  const iteratee = ({
-    value,
-  }: {
-    key: string | number;
-    value: number;
-  }): number => value;
+  const iteratee = ({ value }: { key: PropertyKey; value: number }): number =>
+    value;
 
   bench('modern-kit/mapValues', () => {
     mapValues(obj, iteratee);

--- a/packages/utils/src/object/mapValues/mapValues.bench.ts
+++ b/packages/utils/src/object/mapValues/mapValues.bench.ts
@@ -1,6 +1,7 @@
 import { bench, describe } from 'vitest';
 import { mapValues as mapValuesLodash } from 'lodash-es';
 import { mapValues } from '.';
+
 describe('mapValues', () => {
   const obj = {
     a: 1,

--- a/packages/utils/src/object/mapValues/mapValues.spec.ts
+++ b/packages/utils/src/object/mapValues/mapValues.spec.ts
@@ -1,0 +1,48 @@
+import { mapValues } from '.';
+
+describe('mapValues', () => {
+  it('should map object values by extracting age property', () => {
+    const users = {
+      fred: { user: 'fred', age: 40 },
+      pebbles: { user: 'pebbles', age: 1 },
+    };
+
+    const iteratee = ({
+      value,
+    }: {
+      key: string | number;
+      value: { user: string; age: number };
+    }): number => value.age;
+    const expected = { fred: 40, pebbles: 1 };
+
+    const result = mapValues(users, iteratee);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should map object values by transforming to uppercase string', () => {
+    const obj = { a: 'apple', b: 'banana', c: 'cherry' } as const;
+    const iteratee = ({
+      value,
+    }: {
+      key: string | number;
+      value: string;
+    }): string => value.toUpperCase();
+    const expected = { a: 'APPLE', b: 'BANANA', c: 'CHERRY' } as const;
+
+    const result = mapValues(obj, iteratee);
+
+    expect(result).toEqual(expected);
+  });
+
+  it('should return an empty object for an empty input object', () => {
+    const obj = {};
+    const iteratee = ({ value }: { key: string | number; value: any }): any =>
+      value;
+    const expected = {};
+
+    const result = mapValues(obj, iteratee);
+
+    expect(result).toEqual(expected);
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #320 

`mapValues` 주어진 객체의 각 값에 대해 제공된 변환 함수를 호출하여 새 객체를 생성하는 함수입니다.

기존에 `mapValues` 함수를 구현할 때 `object` 매개변수 타입에 심볼 타입을 추가하여 작업을 진행했었습니다.
심볼 타입을 사용하면 심볼 `Object.getOwnPropertySymbols` 같은 메서드를 사용해야 하는데, 추가적으로 문자열 키만을 처리할 떄 보다 조건 연산 코드가 생기고, 대부분 mapValues 함수에서 `object` 매개변수에 심볼을 드물게 사용하는 것 같아, 
`object` 타입에서 심볼 타입을 제외하고 string과 number 타입만 포함해서 `mapValues` 함수를 구현했습니다. 

```typescript
object: Record<string | number | symbol, T> -> object: Record<string | number, T> 
```

심볼 타입을 제외하는 게 더 나은 접근일지 이 부분 메인테이너 분의 피드백을 받아보고 싶습니다. 
감사합니다.


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)