### PR TITLE
fix(react): useBlockPromiseMultipleClick 

### DIFF
--- a/.changeset/many-pumpkins-tie.md
+++ b/.changeset/many-pumpkins-tie.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": patch
+---
+
+fix(react): useBlockPromiseMultipleClick isLoading 이슈 해결 - @Sangminnn

--- a/packages/react/src/hooks/useBlockPromiseMultipleClick/index.ts
+++ b/packages/react/src/hooks/useBlockPromiseMultipleClick/index.ts
@@ -1,22 +1,28 @@
-import { useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 export function useBlockPromiseMultipleClick() {
   const [isLoading, setIsLoading] = useState(false);
   const isClicked = useRef(false);
 
-  const blockMultipleClick = async (callback: () => Promise<unknown>) => {
-    if (isClicked.current) {
-      return;
-    }
+  const blockMultipleClick = useCallback(
+    async <T>(callback: () => Promise<T>) => {
+      if (isClicked.current) {
+        return;
+      }
 
-    isClicked.current = true;
-    setIsLoading(true);
+      isClicked.current = true;
+      setIsLoading(true);
 
-    await callback();
-
-    isClicked.current = false;
-    setIsLoading(false);
-  };
+      try {
+        const result = await callback();
+        return result;
+      } finally {
+        isClicked.current = false;
+        setIsLoading(false);
+      }
+    },
+    [],
+  );
 
   return {
     isLoading,


### PR DESCRIPTION
해당 훅 사용 시 Error 상황에서 isLoading값이 변경되지 않는 이슈가 있어 코드를 수정했습니다.

그 과정에서 기존에 blockMultipleClick 함수가 훅 내부에서 state의 변경에도 불필요하게 재생성되지 않도록 memoization을 적용했습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)