### PR TITLE
feat(react): useToggleState 훅 추가

### DIFF
--- a/.changeset/fuzzy-countries-compare.md
+++ b/.changeset/fuzzy-countries-compare.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": minor
+---
+
+feat(react): useToggleState 훅 추가 - @Sangminnn

--- a/docs/docs/react/hooks/useToggleState.mdx
+++ b/docs/docs/react/hooks/useToggleState.mdx
@@ -1,0 +1,31 @@
+# useToggleState
+
+두 개의 값을 토글하는 기능을 제공하는 훅입니다.
+
+기본값으로 제공된 두 개의 값을 관리하며, 선택된 값과 두 값을 토글할 수 있는 함수를 반환합니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useToggleState/index.ts)
+
+## Interface
+```ts title="typescript"
+function useToggleState<T>(value1: T, value2: T): [T, () => void]
+```
+
+## Usage
+```tsx title="typescript"
+import { useToggleState } from '@modern-kit/react';
+
+const Example = () => {
+  const [value, toggle] = useToggleState('ON', 'OFF');
+
+  return (
+    <div>
+      {value}
+      <button onClick={toggle}>Toggle Button</button>
+    </div>
+  );
+}
+```

--- a/docs/docs/react/hooks/useToggleState.mdx
+++ b/docs/docs/react/hooks/useToggleState.mdx
@@ -1,3 +1,5 @@
+import { useToggleState } from '@modern-kit/react';
+
 # useToggleState
 
 두 개의 값을 토글하는 기능을 제공하는 훅입니다.
@@ -29,3 +31,18 @@ const Example = () => {
   );
 }
 ```
+
+## Example
+
+export const Example = () => {
+  const [value, toggle] = useToggleState('ON', 'OFF');
+
+  return (
+    <div>
+      {value}
+      <button onClick={toggle}>Toggle Button</button>
+    </div>
+  );
+}
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -38,6 +38,7 @@ export * from './useStepState';
 export * from './useThrottle';
 export * from './useTimeout';
 export * from './useToggle';
+export * from './useToggleState';
 export * from './useUnmount';
 export * from './useUserAgent';
 export * from './useVhProperty';

--- a/packages/react/src/hooks/useToggle/index.ts
+++ b/packages/react/src/hooks/useToggle/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useToggleState } from '../useToggleState';
 
 /**
  * @description boolean 값을 토글하는 기능을 제공하는 훅입니다.
@@ -18,11 +18,5 @@ import { useCallback, useState } from 'react';
  * isToggled; // true
  */
 export function useToggle(defaultValue = false): [boolean, () => void] {
-  const [boolean, setBoolean] = useState(defaultValue);
-
-  const toggle = useCallback(() => {
-    setBoolean((prevBoolean) => !prevBoolean);
-  }, []);
-
-  return [boolean, toggle];
+  return useToggleState(defaultValue, !defaultValue);
 }

--- a/packages/react/src/hooks/useToggleState/index.ts
+++ b/packages/react/src/hooks/useToggleState/index.ts
@@ -1,11 +1,12 @@
 import { useCallback, useState } from 'react';
 /**
- *
- * @param value1 {T}
- * @param value2 {T}
- * @returns {[T, () => void]}
  * @description 두 개의 값을 토글하는 기능을 제공하는 훅입니다.
  * 기본값으로 제공된 두 개의 값을 관리하며, 선택된 값과 두 값을 토글할 수 있는 함수를 반환합니다.
+ *
+ * @template T - 토글할 값의 타입을 나타냅니다.
+ * @param {T} value1 - 초기값이자 첫 번째 토글 값입니다.
+ * @param {T} value2 - 두 번째 토글 값입니다.
+ * @returns {[T, () => void]}
  *
  * @example
  * const [value, toggle] = useToggle('ON', 'OFF');
@@ -13,7 +14,6 @@ import { useCallback, useState } from 'react';
  * value; // 'ON'
  * toggle();
  * value; // 'OFF'
- *
  */
 export function useToggleState<T>(value1: T, value2: T): [T, () => void] {
   const [value, setValue] = useState(value1);

--- a/packages/react/src/hooks/useToggleState/index.ts
+++ b/packages/react/src/hooks/useToggleState/index.ts
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+/**
+ *
+ * @param value1 {T}
+ * @param value2 {T}
+ * @returns {[T, () => void]}
+ * @description 두 개의 값을 토글하는 기능을 제공하는 훅입니다.
+ * 기본값으로 제공된 두 개의 값을 관리하며, 선택된 값과 두 값을 토글할 수 있는 함수를 반환합니다.
+ *
+ * @example
+ * const [value, toggle] = useToggle('ON', 'OFF');
+ *
+ * value; // 'ON'
+ * toggle();
+ * value; // 'OFF'
+ *
+ */
+export function useToggleState<T>(value1: T, value2: T): [T, () => void] {
+  const [value, setValue] = useState(value1);
+
+  const toggle = useCallback(() => {
+    setValue((prev) => (prev === value1 ? value2 : value1));
+  }, [value1, value2]);
+
+  return [value, toggle];
+}

--- a/packages/react/src/hooks/useToggleState/useToggleState.spec.ts
+++ b/packages/react/src/hooks/useToggleState/useToggleState.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useToggleState } from '.';
+
+describe('useToggleState', () => {
+  it('should initialize with the correct initial state', async () => {
+    const { result } = renderHook(() => useToggleState('ON', 'OFF'));
+    const [value] = result.current;
+
+    expect(value).toEqual('ON');
+  });
+
+  it('should toggle the state between value1 and value2 when executed.', async () => {
+    const { result } = renderHook(() => useToggleState('ON', 'OFF'));
+    const toggle = result.current[1];
+
+    expect(result.current[0]).toEqual('ON');
+
+    await waitFor(() => toggle());
+
+    expect(result.current[0]).toEqual('OFF');
+
+    await waitFor(() => toggle());
+
+    expect(result.current[0]).toEqual('ON');
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #491 

두 개의 값을 토글하는 기능을 제공하는 훅입니다.

기본값으로 제공된 두 개의 값을 관리하며, 선택된 값과 두 값을 토글할 수 있는 함수를 반환합니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)