### PR TITLE
feat(react): useFocus 신규 훅 추가

### DIFF
--- a/.changeset/heavy-onions-allow.md
+++ b/.changeset/heavy-onions-allow.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": minor
+---
+
+feat(react): useFocus 신규 훅 추가 - @99mini

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -34,17 +34,17 @@ const useFocus<T extends HTMLElement>({
 import { useFocus } from '@modern-kit/react';
 
 const Example = () => {
-    const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
-        focusAction: () => console.log("포커스"),
-        blurAction: () => console.log("포커스 해제"),
-    });
+  const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
+    focusAction: () => console.log("포커스"),
+    blurAction: () => console.log("포커스 해제"),
+  });
 
-    return (
-        <>
-            <input ref={ref} />
-            <button onClick={() => setFocus()}>focus trigger</button>
-            <div>{isFocus ? 'Focus' : 'Blur'}</div>
-        </>
-    )
+  return (
+    <>
+      <input ref={ref} />
+      <button onClick={() => setFocus()}>focus trigger</button>
+      <div>{isFocus ? 'Focus' : 'Blur'}</div>
+    </>
+  )
 };
 ```

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -23,9 +23,9 @@ interface UseFocusReturnType<T extends HTMLElement> {
   setFocus: () => void;
 }
 
-const useFocus<T extends HTMLElement>({
-  onFocus = noop,
-  onBlur = noop,
+function useFocus<T extends HTMLElement>({
+  onFocus,
+  onBlur,
 }: UseFocusProps = {}): UseFocusReturnType<T>
 ```
 

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -1,0 +1,50 @@
+import { useFocus } from '@modern-kit/react';
+
+# useFocus
+
+대상 요소를 기준으로 포커스 상태를 반환하고, 포커스 상태에 따른 액션을 정의할 수 있는 커스텀 훅입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useFocus/index.ts)
+
+## Interface
+```ts title="typescript"
+
+interface UseFocusProps {
+  focusAction?: (event: FocusEvent) => void;
+  blurAction?: (event: FocusEvent) => void;
+}
+
+interface UseFocusReturnType<T extends HTMLElement> {
+  ref: React.RefObject<T>;
+  isFocus: boolean;
+  setFocus: () => void;
+}
+
+const useFocus<T extends HTMLElement>({
+  focusAction = noop,
+  blurAction = noop,
+}: UseFocusProps = {}): UseFocusReturnType<T>
+```
+
+## Usage
+```tsx title="typescript"
+import { useFocus } from '@modern-kit/react';
+
+const Example = () => {
+    const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
+        focusAction: () => console.log("포커스"),
+        blurAction: () => console.log("포커스 해제"),
+    });
+
+    return (
+        <>
+            <input ref={ref} />
+            <button onClick={() => setFocus()}>focus trigger</button>
+            <div>{isFocus ? 'Focus' : 'Blur'}</div>
+        </>
+    )
+};
+```

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -18,7 +18,7 @@ interface UseFocusProps {
 }
 
 interface UseFocusReturnType<T extends HTMLElement> {
-  ref: React.RefObject<T>;
+  ref: RefObject<T>;
   isFocus: boolean;
   setFocus: () => void;
 }

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -35,16 +35,35 @@ import { useFocus } from '@modern-kit/react';
 
 const Example = () => {
   const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
-    focusAction: () => console.log("포커스"),
-    blurAction: () => console.log("포커스 해제"),
+    focusAction: () => console.log("focus"),
+    blurAction: () => console.log("blur"),
   });
 
   return (
-    <>
+    <div>
       <input ref={ref} />
       <button onClick={() => setFocus()}>focus trigger</button>
       <div>{isFocus ? 'Focus' : 'Blur'}</div>
-    </>
+    </div>
   )
 };
 ```
+
+## Example
+
+export const Example = () => {
+  const { ref, isFocus, setFocus } = useFocus({
+    focusAction: () => console.log("focus"),
+    blurAction: () => console.log("blur"),
+  });
+
+  return (
+    <div>
+      <input ref={ref} />
+      <button onClick={() => setFocus()}>focus trigger</button>
+      <div>{isFocus ? 'Focus' : 'Blur'}</div>
+    </div>
+  )
+};
+
+<Example />

--- a/docs/docs/react/hooks/useFocus.mdx
+++ b/docs/docs/react/hooks/useFocus.mdx
@@ -13,8 +13,8 @@ import { useFocus } from '@modern-kit/react';
 ```ts title="typescript"
 
 interface UseFocusProps {
-  focusAction?: (event: FocusEvent) => void;
-  blurAction?: (event: FocusEvent) => void;
+  onFocus?: (event: FocusEvent) => void;
+  onBlur?: (event: FocusEvent) => void;
 }
 
 interface UseFocusReturnType<T extends HTMLElement> {
@@ -24,8 +24,8 @@ interface UseFocusReturnType<T extends HTMLElement> {
 }
 
 const useFocus<T extends HTMLElement>({
-  focusAction = noop,
-  blurAction = noop,
+  onFocus = noop,
+  onBlur = noop,
 }: UseFocusProps = {}): UseFocusReturnType<T>
 ```
 
@@ -35,8 +35,8 @@ import { useFocus } from '@modern-kit/react';
 
 const Example = () => {
   const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
-    focusAction: () => console.log("focus"),
-    blurAction: () => console.log("blur"),
+    onFocus: () => console.log("focus"),
+    onBlur: () => console.log("blur"),
   });
 
   return (
@@ -53,8 +53,8 @@ const Example = () => {
 
 export const Example = () => {
   const { ref, isFocus, setFocus } = useFocus({
-    focusAction: () => console.log("focus"),
-    blurAction: () => console.log("blur"),
+    onFocus: () => console.log("focus"),
+    onBlur: () => console.log("blur"),
   });
 
   return (

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -11,6 +11,7 @@ export * from './useDebouncedState';
 export * from './useDocumentTitle';
 export * from './useEventListener';
 export * from './useFileReader';
+export * from './useFocus';
 export * from './useForceUpdate';
 export * from './useHover';
 export * from './useImageStatus';

--- a/packages/react/src/hooks/useFocus/index.ts
+++ b/packages/react/src/hooks/useFocus/index.ts
@@ -1,6 +1,6 @@
-import React from 'react';
-import { useEventListener } from '../../hooks/useEventListener';
 import { noop } from '@modern-kit/utils';
+import { RefObject, useRef, useState, useCallback } from 'react';
+import { useEventListener } from '../../hooks/useEventListener';
 
 interface UseFocusProps {
   focusAction?: (event: FocusEvent) => void;
@@ -8,7 +8,7 @@ interface UseFocusProps {
 }
 
 interface UseFocusReturnType<T extends HTMLElement> {
-  ref: React.RefObject<T>;
+  ref: RefObject<T>;
   isFocus: boolean;
   setFocus: () => void;
 }
@@ -43,11 +43,11 @@ export function useFocus<T extends HTMLElement>({
   focusAction = noop,
   blurAction = noop,
 }: UseFocusProps = {}): UseFocusReturnType<T> {
-  const [isFocus, setIsFocus] = React.useState(false);
+  const [isFocus, setIsFocus] = useState(false);
 
-  const ref = React.useRef<T>(null);
+  const ref = useRef<T>(null);
 
-  const onFocus = React.useCallback(
+  const onFocus = useCallback(
     (event: FocusEvent) => {
       setIsFocus(true);
       focusAction(event);
@@ -55,7 +55,7 @@ export function useFocus<T extends HTMLElement>({
     [focusAction]
   );
 
-  const onBlur = React.useCallback(
+  const onBlur = useCallback(
     (event: FocusEvent) => {
       setIsFocus(false);
       blurAction(event);
@@ -63,7 +63,7 @@ export function useFocus<T extends HTMLElement>({
     [blurAction]
   );
 
-  const setFocus = React.useCallback(() => {
+  const setFocus = useCallback(() => {
     if (ref.current) {
       ref.current.focus();
       setIsFocus(true);

--- a/packages/react/src/hooks/useFocus/index.ts
+++ b/packages/react/src/hooks/useFocus/index.ts
@@ -30,15 +30,17 @@ interface UseFocusReturnType<T extends HTMLElement> {
  * - `isFocus`: 요소가 포커스 상태인지 여부를 나타내는 불리언 값입니다.
  * - `setFocus`: 요소에 포커스를 참 값으로 설정하는 함수입니다.
  *
- * @example
- * const { ref, isFocused, setFocus } = useFocus<HTMLInputElement>({
- *   onFocus: () => console.log("focus"),
- *   onBlur: () => console.log("blur")
- * });
- *
- * <input ref={ref} />
- * <button onClick={() => setFocus()}>focus trigger</button>
- * <div>{isFocused ? 'focus' : 'blur'}</div>
+* @example
+* ```tsx
+* const { ref, isFocused, setFocus } = useFocus<HTMLInputElement>({
+*   onFocus: () => console.log("focus"),
+*   onBlur: () => console.log("blur")
+* });
+*
+* <input ref={ref} />
+* <button onClick={() => setFocus()}>focus trigger</button>
+* <div>{isFocused ? 'focus' : 'blur'}</div>
+* ```
  */
 export function useFocus<T extends HTMLElement>({
   onFocus = noop,

--- a/packages/react/src/hooks/useFocus/index.ts
+++ b/packages/react/src/hooks/useFocus/index.ts
@@ -31,13 +31,13 @@ interface UseFocusReturnType<T extends HTMLElement> {
  *
  * @example
  * const { ref, isFocused, setFocus } = useFocus<HTMLInputElement>({
- *   focusAction: () => console.log("포커스"),
- *   blurAction: () => console.log("포커스 해제")
+ *   focusAction: () => console.log("focus"),
+ *   blurAction: () => console.log("blur")
  * });
  *
  * <input ref={ref} />
- * <button onClick={() => setFocus()}>Input 포커스</button>
- * <div>{isFocused ? '포커스' : '포커스 해제'}</div>
+ * <button onClick={() => setFocus()}>focus trigger</button>
+ * <div>{isFocused ? 'focus' : 'blur'}</div>
  */
 export function useFocus<T extends HTMLElement>({
   focusAction = noop,

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, Mock, vi } from 'vitest';
 import { useFocus } from '.';
 import { renderSetup } from '../../utils/test/renderSetup';
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 
 const TestComponent = ({
   focusMockFn,
@@ -43,14 +43,16 @@ describe('useFocus', () => {
     const targetTrigger = screen.getByRole('target-trigger');
     const targetStatus = screen.getByRole('target-status');
 
-    await user.click(targetTrigger);
-
+    await act(async () => {
+      await user.click(targetTrigger);
+    });
     expect(focusTarget).toHaveFocus();
     expect(targetStatus.textContent).toBe('Focus');
     expect(focusMockFn).toBeCalled();
 
-    await user.click(targetStatus);
-
+    await act(async () => {
+      await user.click(targetStatus);
+    });
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).toBeCalled();
@@ -70,14 +72,16 @@ describe('useFocus without connected ref', () => {
     const targetTrigger = screen.getByRole('target-trigger');
     const targetStatus = screen.getByRole('target-status');
 
-    await user.click(targetTrigger);
-
+    await act(async () => {
+      await user.click(targetTrigger);
+    });
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(focusMockFn).not.toBeCalled();
 
-    await user.click(targetStatus);
-
+    await act(async () => {
+      await user.click(targetStatus);
+    });
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).not.toBeCalled();

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, Mock, vi } from 'vitest';
+import { useFocus } from '.';
+import { renderSetup } from '../../utils/test/renderSetup';
+import { screen } from '@testing-library/react';
+
+const TestComponent = ({
+  focusMockFn,
+  blurMockFn,
+  connectedRef,
+}: {
+  focusMockFn?: Mock<any, any>;
+  blurMockFn?: Mock<any, any>;
+  connectedRef?: boolean;
+}) => {
+  const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
+    focusAction: focusMockFn,
+    blurAction: blurMockFn,
+  });
+
+  return (
+    <div>
+      <input ref={connectedRef ? ref : undefined} role="focus-target" />
+      <button role="target-trigger" onClick={() => setFocus()} />
+      <div role="target-status">{isFocus ? 'Focus' : 'Blur'}</div>
+    </div>
+  );
+};
+
+describe('useFocus', () => {
+  it('should trigger callback at target focus and blur', async () => {
+    const focusMockFn = vi.fn();
+    const blurMockFn = vi.fn();
+
+    const { user } = renderSetup(
+      <TestComponent
+        focusMockFn={focusMockFn}
+        blurMockFn={blurMockFn}
+        connectedRef
+      />
+    );
+
+    const focusTarget = screen.getByRole('focus-target');
+    const targetTrigger = screen.getByRole('target-trigger');
+    const targetStatus = screen.getByRole('target-status');
+
+    await user.click(targetTrigger);
+
+    expect(focusTarget).toHaveFocus();
+    expect(targetStatus.textContent).toBe('Focus');
+    expect(focusMockFn).toBeCalled();
+
+    await user.click(targetStatus);
+
+    expect(focusTarget).not.toHaveFocus();
+    expect(targetStatus.textContent).toBe('Blur');
+    expect(blurMockFn).toBeCalled();
+  });
+});
+
+describe('useFocus without connected ref', () => {
+  it('should not throw error when ref is not connected', async () => {
+    const focusMockFn = vi.fn();
+    const blurMockFn = vi.fn();
+
+    const { user } = renderSetup(
+      <TestComponent focusMockFn={focusMockFn} blurMockFn={blurMockFn} />
+    );
+
+    const focusTarget = screen.getByRole('focus-target');
+    const targetTrigger = screen.getByRole('target-trigger');
+    const targetStatus = screen.getByRole('target-status');
+
+    await user.click(targetTrigger);
+
+    expect(focusTarget).not.toHaveFocus();
+    expect(targetStatus.textContent).toBe('Blur');
+    expect(focusMockFn).not.toBeCalled();
+
+    await user.click(targetStatus);
+
+    expect(focusTarget).not.toHaveFocus();
+    expect(targetStatus.textContent).toBe('Blur');
+    expect(blurMockFn).not.toBeCalled();
+  });
+});

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -57,9 +57,7 @@ describe('useFocus', () => {
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).toBeCalled();
   });
-});
 
-describe('useFocus without connected ref', () => {
   it('should not throw error when ref is not connected', async () => {
     const focusMockFn = vi.fn();
     const blurMockFn = vi.fn();
@@ -85,5 +83,25 @@ describe('useFocus without connected ref', () => {
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).not.toBeCalled();
+  });
+
+  it('should not throw error when focusAction and blurAction is not provided', async () => {
+    const { user } = renderSetup(<TestComponent connectedRef />);
+
+    const focusTarget = screen.getByRole('focus-target');
+    const targetTrigger = screen.getByRole('target-trigger');
+    const targetStatus = screen.getByRole('target-status');
+
+    await act(async () => {
+      await user.click(targetTrigger);
+    });
+    expect(focusTarget).toHaveFocus();
+    expect(targetStatus.textContent).toBe('Focus');
+
+    await act(async () => {
+      await user.click(targetStatus);
+    });
+    expect(focusTarget).not.toHaveFocus();
+    expect(targetStatus.textContent).toBe('Blur');
   });
 });

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -13,8 +13,8 @@ const TestComponent = ({
   connectedRef?: boolean;
 }) => {
   const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
-    focusAction: focusMockFn,
-    blurAction: blurMockFn,
+    onFocus: focusMockFn,
+    onBlur: blurMockFn,
   });
 
   return (

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -56,7 +56,7 @@ describe('useFocus', () => {
     expect(blurMockFn).toBeCalled();
   });
 
-  it('should not throw error when ref is not connected', async () => {
+  it('should not perform any actions when ref is not assigned', async () => {
     const focusMockFn = vi.fn();
     const blurMockFn = vi.fn();
 
@@ -81,7 +81,7 @@ describe('useFocus', () => {
     expect(blurMockFn).not.toBeCalled();
   });
 
-  it('should not throw error when focusAction and blurAction is not provided', async () => {
+  it('should not perform any actions when onFocus and onBlur are not assigned', async () => {
     const { user } = renderSetup(<TestComponent connectedRef />);
 
     const focusTarget = screen.getByRole('focus-target');

--- a/packages/react/src/hooks/useFocus/useFocus.spec.tsx
+++ b/packages/react/src/hooks/useFocus/useFocus.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, Mock, vi } from 'vitest';
 import { useFocus } from '.';
 import { renderSetup } from '../../utils/test/renderSetup';
-import { act, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
 const TestComponent = ({
   focusMockFn,
@@ -43,16 +43,14 @@ describe('useFocus', () => {
     const targetTrigger = screen.getByRole('target-trigger');
     const targetStatus = screen.getByRole('target-status');
 
-    await act(async () => {
-      await user.click(targetTrigger);
-    });
+    await user.click(targetTrigger);
+
     expect(focusTarget).toHaveFocus();
     expect(targetStatus.textContent).toBe('Focus');
     expect(focusMockFn).toBeCalled();
 
-    await act(async () => {
-      await user.click(targetStatus);
-    });
+    await user.click(targetStatus);
+
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).toBeCalled();
@@ -70,16 +68,14 @@ describe('useFocus', () => {
     const targetTrigger = screen.getByRole('target-trigger');
     const targetStatus = screen.getByRole('target-status');
 
-    await act(async () => {
-      await user.click(targetTrigger);
-    });
+    await user.click(targetTrigger);
+
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(focusMockFn).not.toBeCalled();
 
-    await act(async () => {
-      await user.click(targetStatus);
-    });
+    await user.click(targetStatus);
+
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
     expect(blurMockFn).not.toBeCalled();
@@ -92,15 +88,13 @@ describe('useFocus', () => {
     const targetTrigger = screen.getByRole('target-trigger');
     const targetStatus = screen.getByRole('target-status');
 
-    await act(async () => {
-      await user.click(targetTrigger);
-    });
+    await user.click(targetTrigger);
+
     expect(focusTarget).toHaveFocus();
     expect(targetStatus.textContent).toBe('Focus');
 
-    await act(async () => {
-      await user.click(targetStatus);
-    });
+    await user.click(targetStatus);
+
     expect(focusTarget).not.toHaveFocus();
     expect(targetStatus.textContent).toBe('Blur');
   });


### PR DESCRIPTION
## Overview

Issue: #352 

<!-- Write a description of your work.  -->

`ref`가 할당된 element가 focus 상태인지를 반환하고, 강제로 포커스할 수 있는 함수를 제공합니다.

- `ref`를 등록하지 않거나, 액션(`focusAction`, `blurAction`)을 등록하지 않았을 경우 에러를 던지지 않고, 아무런 동작하지 않습니다.

### Usage
```tsx
const { ref, isFocus, setFocus } = useFocus<HTMLInputElement>({
  focusAction: () => console.log("focus"),
  blurAction: () => console.log("blur"),
});

return (
  <div>
    <input ref={ref} />
    <button onClick={() => setFocus()}>focus trigger</button>
    <div>{isFocus ? 'Focus' : 'Blur'}</div>
  </div>
)
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)