### PR TITLE
ClientGate 컴포넌트 추가

### DIFF
--- a/.changeset/yellow-carpets-bow.md
+++ b/.changeset/yellow-carpets-bow.md
@@ -1,0 +1,6 @@
+---
+"@modern-kit/react": minor
+"@modern-kit/types": minor
+---
+
+feat(react): ClientGate 컴포넌트 추가 - @Sangminnn

--- a/docs/docs/react/components/ClientGate.mdx
+++ b/docs/docs/react/components/ClientGate.mdx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { ClientGate } from '@modern-kit/react';
+
+# ClientGate
+
+Client Side에서는 children을, Server Side에서는 fallback component를 보여주는 컴포넌트입니다.
+
+Pure CSR 환경에서 렌더시에는 첫 라이프 사이클이 수행되어 mount가 완료되기 전부터 해당 component를 보여줍니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/ClientGate/index.tsx)
+
+## Interface
+```ts title="typescript"
+
+interface ClientGateProps {
+  fallback?: JSX.Element;
+}
+
+const ClientGate: ({
+  fallback = <></>
+}: PropsWithChildren<ClientGateProps>) => JSX.Element;
+```
+
+## Usage
+```tsx title="typescript"
+import { ClientGate } from '@modern-kit/react'
+
+const Example = () => {
+  return (
+    <ClientGate fallback={<div>서버 환경입니다.</div>}>
+      <div>클라이언트 환경입니다.</div>
+    </ClientGate>
+  );
+};
+```
+
+## Example
+export const Example = () => {
+  return (
+    <ClientGate fallback={<div>서버 환경입니다.</div>}>
+      <div>클라이언트 환경입니다.</div>
+    </ClientGate>
+  );
+};
+
+<Example />

--- a/docs/docs/react/components/Mounted.mdx
+++ b/docs/docs/react/components/Mounted.mdx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { ClientOnly } from '@modern-kit/react';
+import { Mounted } from '@modern-kit/react';
 
-# ClientOnly
+# Mounted
 
 컴포넌트가 브라우저에 mount 되었을 때 children이 나타나게 해주는 컴포넌트입니다. 즉, children을 렌더링하는 환경이 클라이언트 환경임을 보장할 수 있습니다. mount 전에는 fallback으로 넣어준 컴포넌트를 보여줍니다.
 
@@ -10,29 +10,29 @@ import { ClientOnly } from '@modern-kit/react';
 <br />
 
 ## Code
-[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/ClientOnly/index.tsx)
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/Mounted/index.tsx)
 
 ## Interface
 ```ts title="typescript"
 
-interface ClientOnlyProps {
+interface MountedProps {
   fallback?: JSX.Element;
 }
 
-const ClientOnly: ({
+const Mounted: ({
   fallback = <></>
-}: PropsWithChildren<ClientOnlyProps>) => JSX.Element;
+}: PropsWithChildren<MountedProps>) => JSX.Element;
 ```
 
 ## Usage
 ```tsx title="typescript"
-import { ClientOnly } from '@modern-kit/react'
+import { Mounted } from '@modern-kit/react'
 
 const Example = () => {
   return (
-    <ClientOnly fallback={<div>mount가 완료되기 전입니다.</div>}>
+    <Mounted fallback={<div>mount가 완료되기 전입니다.</div>}>
       <div>mount가 완료되었습니다.</div>
-    </ClientOnly>
+    </Mounted>
   );
 };
 ```
@@ -40,9 +40,9 @@ const Example = () => {
 ## Example
 export const Example = () => {
   return (
-    <ClientOnly fallback={<div>mount가 완료되기 전입니다.</div>}>
+    <Mounted fallback={<div>mount가 완료되기 전입니다.</div>}>
       <div>mount가 완료되었습니다.</div>
-    </ClientOnly>
+    </Mounted>
   );
 };
 

--- a/packages/react/src/components/ClientGate/ClientGate.spec.tsx
+++ b/packages/react/src/components/ClientGate/ClientGate.spec.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+
+import { renderSetup } from '../../utils/test/renderSetup';
+import { renderToString } from 'react-dom/server';
+
+import { ClientGate } from '.';
+
+const TestComponent = () => {
+  return (
+    <ClientGate fallback={<div>fallback component</div>}>
+      <div>children component</div>
+    </ClientGate>
+  );
+};
+
+describe('ClientGate', () => {
+  it('서버사이드 렌더링시에는 fallback 컴포넌트가 나타난다.', () => {
+    const html = renderToString(<TestComponent />);
+
+    expect(html).toContain('fallback component');
+    expect(html).not.toContain('children component');
+  });
+
+  it('클라이언트사이드 렌더링시에는 children 컴포넌트가 나타난다.', () => {
+    renderSetup(<TestComponent />);
+
+    expect(screen.queryByText('fallback component')).not.toBeInTheDocument();
+    expect(screen.getByText('children component')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/ClientGate/index.tsx
+++ b/packages/react/src/components/ClientGate/index.tsx
@@ -1,6 +1,8 @@
 import { PropsWithChildren, useSyncExternalStore } from 'react';
 
-const emptySubscribe = () => () => {};
+import { noop } from '@modern-kit/utils';
+
+const emptySubscribe = () => noop;
 
 interface ClientGateProps {
   fallback?: JSX.Element;

--- a/packages/react/src/components/ClientGate/index.tsx
+++ b/packages/react/src/components/ClientGate/index.tsx
@@ -1,0 +1,20 @@
+import { PropsWithChildren, useSyncExternalStore } from 'react';
+
+const emptySubscribe = () => () => {};
+
+interface ClientGateProps {
+  fallback?: JSX.Element;
+}
+
+export function ClientGate({
+  fallback = <></>,
+  children,
+}: PropsWithChildren<ClientGateProps>) {
+  const isServer = useSyncExternalStore(
+    emptySubscribe,
+    () => false,
+    () => true,
+  );
+
+  return isServer ? fallback : children;
+}

--- a/packages/react/src/components/Mounted/Mounted.spec.tsx
+++ b/packages/react/src/components/Mounted/Mounted.spec.tsx
@@ -4,25 +4,25 @@ import { screen } from '@testing-library/react';
 import { renderSetup } from '../../utils/test/renderSetup';
 import { renderToString } from 'react-dom/server';
 
-import { ClientOnly } from '.';
+import { Mounted } from '.';
 
 const TestComponent = () => {
   return (
-    <ClientOnly fallback={<div>fallback component</div>}>
+    <Mounted fallback={<div>fallback component</div>}>
       <div>children component</div>
-    </ClientOnly>
+    </Mounted>
   );
 };
 
-describe('ClientOnly', () => {
-  it('should render a fallback component before mount', () => {
+describe('Mounted', () => {
+  it('마운트 전에는 fallback 컴포넌트가 나타난다.', () => {
     const html = renderToString(<TestComponent />);
 
     expect(html).toContain('fallback component');
     expect(html).not.toContain('children component');
   });
 
-  it('should render a children component after mount', () => {
+  it('마운트 후에는 children 컴포넌트가 나타난다.', () => {
     renderSetup(<TestComponent />);
 
     expect(screen.queryByText('fallback component')).not.toBeInTheDocument();

--- a/packages/react/src/components/Mounted/index.tsx
+++ b/packages/react/src/components/Mounted/index.tsx
@@ -1,13 +1,13 @@
 import { useIsMounted } from '../../hooks/useIsMounted';
 
-interface ClientOnlyProps {
+interface MountedProps {
   fallback?: JSX.Element;
 }
 
-export const ClientOnly = ({
+export const Mounted = ({
   fallback = <></>,
   children,
-}: React.PropsWithChildren<ClientOnlyProps>) => {
+}: React.PropsWithChildren<MountedProps>) => {
   const isMounted = useIsMounted();
 
   if (!isMounted) return fallback;

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,6 +1,6 @@
 export * from './AspectRatio';
 export * from './ClientGate';
-export * from './ClientOnly';
+export * from './Mounted';
 export * from './DebounceWrapper';
 export * from './FallbackLazyImage';
 export * from './IfElse';

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './AspectRatio';
+export * from './ClientGate';
 export * from './ClientOnly';
 export * from './DebounceWrapper';
 export * from './FallbackLazyImage';

--- a/packages/types/src/NonEmptyArray/index.ts
+++ b/packages/types/src/NonEmptyArray/index.ts
@@ -1,0 +1,1 @@
+export type NonEmptyArray<T> = [T, ...T[]];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -8,6 +8,7 @@ export * from './ExtractSetType';
 export * from './IndexSignature';
 export * from './Integer';
 export * from './NaturalNumber';
+export * from './NonEmptyArray';
 export * from './Nullable';
 export * from './ObjectEntries';
 export * from './ObjectKeys';


### PR DESCRIPTION
## Overview

Issue: #513 

Client Side에서는 children을, Server Side에서는 fallback component를 보여주는 컴포넌트입니다.

Pure CSR 환경에서 렌더시에는 첫 라이프 사이클이 수행되어 mount가 완료되기 전부터 해당 component를 보여줍니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)