### PR TITLE
feat(react): useDependencyTimeout 구현

### DIFF
--- a/.changeset/polite-bulldogs-peel.md
+++ b/.changeset/polite-bulldogs-peel.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": minor
+---
+
+feat(react): useDependencyTimeout 구현 - @Collection50

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -1,0 +1,78 @@
+import { useDependencyTimeout } from '@modern-kit/react';
+import { useState, DependencyList } from 'react';
+
+# useDependencyTimeout
+
+`useTimeout`를 dependency로 관리해 사용할 수 있는 커스텀 훅 입니다. 
+
+`callback` 함수, `delay` 숫자, `deps` 배열, 첫 마운트 여부를 수행하는 `{ callOnMount }`를 받습니다.
+
+Timeout을 직접 핸들링 할 수 있는 `set`, `reset`, `clear` 함수를 반환합니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useDependencyTimeout/index.ts)
+
+## Interface
+```ts title="typescript"
+interface TimeoutOptions {
+  callback: () => void;
+  options: number | TimeoutOptions;
+  deps: DependencyList[];
+  { callOnMount }: { callOnMount: boolean }
+}
+```
+
+## Usage
+```tsx title="typescript"
+import { useDependencyTimeout } from '@modern-kit/react';
+
+const Example = () => {
+  const [number, setNumber] = useState(0);
+
+  const { set, reset, clear } = useDependencyTimeout(() => {
+    setNumber(number + 1);
+  }, 1000);
+
+  /*
+   * useDependencyTimeout(() => {
+   *   setNumber(number + 1);
+   * }, { delay: 1000, enabled: true });
+   */
+
+  return (
+    <div>
+      <p>{number}</p>
+      <div>
+        <button onClick={() => set()}>set</button>
+        <button onClick={() => reset()}>reset</button>
+        <button onClick={() => clear()}>clear</button>
+      </div>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = ({ deps }) => {
+  const [number, setNumber] = useState(0);
+
+  const { set, reset, clear } = useDependencyTimeout(() => {
+    setNumber(number + 1);
+  }, { delay: 1000, enabled: true }, deps);
+
+  return (
+    <div>
+      <p>{number}</p>
+      <div>
+        <button onClick={() => set()}>set</button>
+        <button onClick={() => reset()}>reset</button>
+        <button onClick={() => clear()}>clear</button>
+      </div>
+    </div>
+  );
+};
+
+<Example />

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -55,17 +55,18 @@ const Example = () => {
 ```
 
 ## Example
-
-export const Example = ({ deps }) => {
+export const Example = () => {
   const [number, setNumber] = useState(0);
+  const [boolean, setBoolean] = useState(false);
 
   const { set, reset, clear } = useDependencyTimeout(() => {
     setNumber(number + 1);
-  }, { delay: 1000, enabled: true }, deps);
+  }, 1000, [boolean]);
 
   return (
     <div>
       <p>{number}</p>
+      <button onClick={() => setBoolean(!boolean)}>Toggle 의존성 배열 수정</button>
       <div>
         <button onClick={() => set()}>set</button>
         <button onClick={() => reset()}>reset</button>

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -3,11 +3,13 @@ import { useState, DependencyList } from 'react';
 
 # useDependencyTimeout
 
-`useTimeout`를 dependency로 관리해 사용할 수 있는 커스텀 훅 입니다. 
+**[useTimeout](https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useTimeout)** 을 사용해 인자로 전달하는 의존성 배열의 값이 변경되면 `Timeout`을 재설정하는 커스텀 훅입니다.
 
-`callback` 함수, `delay` 숫자, `deps` 배열, 첫 마운트 여부를 수행하는 `{ callOnMount }`를 받습니다.
+첫 번째 인자로 `callback` 함수를 받습니다. 
+두 번째 인자로 `delay` 숫자 혹은 `TimerOptions`를 받을 수 있습니다. `TimerOptions`는 `delay`와 `enabled`를 포함하는 객체입니다.
+세 번째 인자는 의존성 배열인 `deps` 입니다. 해당 의존성 배열 내 값이 바뀌면 `Timeout`을 재설정합니다. 
 
-Timeout을 직접 핸들링 할 수 있는 `set`, `reset`, `clear` 함수를 반환합니다.
+`Timeout`을 직접 핸들링 할 수 있는 `set`, `reset`, `clear` 함수를 포함한 객체를 반환합니다.
 
 <br />
 

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -20,7 +20,6 @@ interface TimeoutOptions {
   callback: () => void;
   options: number | TimeoutOptions;
   deps: DependencyList[];
-  { callOnMount }: { callOnMount: boolean }
 }
 ```
 

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -16,11 +16,17 @@ Timeout을 직접 핸들링 할 수 있는 `set`, `reset`, `clear` 함수를 반
 
 ## Interface
 ```ts title="typescript"
-interface TimeoutOptions {
-  callback: () => void;
-  options: number | TimeoutOptions;
-  deps: DependencyList[];
-}
+export function useDependencyTimeout(
+  callback: () => void,
+  delay: number,
+  deps: DependencyList
+): ReturnType<typeof useTimeout>;
+
+export function useDependencyTimeout(
+  callback: () => void,
+  options: TimeoutOptions,
+  deps: DependencyList
+): ReturnType<typeof useTimeout>;
 ```
 
 ## Usage

--- a/docs/docs/react/hooks/useDependencyTimeout.mdx
+++ b/docs/docs/react/hooks/useDependencyTimeout.mdx
@@ -30,11 +30,12 @@ import { useDependencyTimeout } from '@modern-kit/react';
 
 const Example = () => {
   const [number, setNumber] = useState(0);
+  const [boolean, setBoolean] = useState(false);
 
   const { set, reset, clear } = useDependencyTimeout(() => {
     setNumber(number + 1);
-  }, 1000);
-
+  }, 1000, [boolean]);
+  
   /*
    * useDependencyTimeout(() => {
    *   setNumber(number + 1);
@@ -44,6 +45,7 @@ const Example = () => {
   return (
     <div>
       <p>{number}</p>
+      <button onClick={() => setBoolean(!boolean)}>Toggle 의존성 배열 수정</button>
       <div>
         <button onClick={() => set()}>set</button>
         <button onClick={() => reset()}>reset</button>

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -45,3 +45,4 @@ export * from './useUserAgent';
 export * from './useVhProperty';
 export * from './useVisibilityChange';
 export * from './useWindowSize';
+export * from './useDependencyTimeout';

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -4,7 +4,8 @@ import { getTimeoutOptions } from '../useTimeout/useTimeout.utils';
 import type { TimeoutOptions } from '../useTimeout/useTimeout.types';
 
 /**
- * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ * @description `useTimeout`을 사용해 인자로 전달하는 의존성 배열의 값이 변경되면 `Timeout`을 재설정하는 커스텀 훅입니다.
+ * @see https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useTimeout
  *
  * @param {() => void} callback - delay 후에 실행될 함수입니다.
  * @param {number} delay - 밀리초(ms) 단위의 지연 시간
@@ -20,7 +21,8 @@ export function useDependencyTimeout(
 ): ReturnType<typeof useTimeout>;
 
 /**
- * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ * @description `useTimeout`을 사용해 인자로 전달하는 의존성 배열의 값이 변경되면 `Timeout`을 재설정하는 커스텀 훅입니다.
+ * @see https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useTimeout
  *
  * @param {() => void} callback - delay 후에 실행될 함수입니다.
  * @param {TimeoutOptions} options - timeout 옵션입니다. enabled, delay를 포함 합니다.
@@ -36,7 +38,8 @@ export function useDependencyTimeout(
 ): ReturnType<typeof useTimeout>;
 
 /**
- * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ * @description `useTimeout`을 사용해 인자로 전달하는 의존성 배열의 값이 변경되면 `Timeout`을 재설정하는 커스텀 훅입니다.
+ * @see https://modern-agile-team.github.io/modern-kit/docs/react/hooks/useTimeout
  *
  * @param {() => void} callback - delay 후에 실행될 함수입니다.
  * @param {number | TimeoutOptions} options - 밀리초(ms) 단위의 지연 시간 또는 옵션 객체(delay, enabled)입니다.

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -28,7 +28,7 @@ export function useDependencyTimeout(
  * @example
  * useDependencyTimeout(callback, { delay: 300, enabled }, [condition]);
  */
-export default function useDependencyTimeout(
+export function useDependencyTimeout(
   callback: () => void,
   options: number | TimeoutOptions,
   deps: DependencyList

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -35,7 +35,7 @@ export function useDependencyTimeout(
 ): ReturnType<typeof useTimeout> {
   const { delay, enabled } = getTimeoutOptions(options);
 
-  const { set, reset, clear } = useTimeout(callback, delay);
+  const { set, reset, clear } = useTimeout(callback, { delay, enabled: false });
 
   useEffect(() => {
     if (delay < 0 || !enabled) return;

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -1,14 +1,19 @@
-// /*
-//   callback: 실행 할 콜백
-//   delay: timeout delay
-//   deps: 의존성 배열
-//   callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정
-// */
-// useDependencyTimeout(callback, delay, deps, { callOnMount });
-
 import { useEffect, useRef } from 'react';
-import { useTimeout } from '../useTimeout';
+import { useTimeout } from 'hooks/useTimeout';
 
+/**
+ * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ *
+ * @param callback: 실행 할 콜백
+ * @param delay: timeout delay
+ * @param deps: 의존성 배열
+ * @param callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정 *
+ *
+ * @return {ReturnType<typeof useTimeout>}
+ *
+ * @example
+ * const { set, reset, clear } = useDependencyTimeout(() => console.log(something), 500, deps);
+ */
 export default function useDependencyTimeout(
   callback: () => void,
   delay: number,

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -1,0 +1,32 @@
+// /*
+//   callback: 실행 할 콜백
+//   delay: timeout delay
+//   deps: 의존성 배열
+//   callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정
+// */
+// useDependencyTimeout(callback, delay, deps, { callOnMount });
+
+import { useEffect, useRef } from 'react';
+import { useTimeout } from '../useTimeout';
+
+export default function useDependencyTimeout(
+  callback: () => void,
+  delay: number,
+  deps: unknown[],
+  { callOnMount }: { callOnMount: boolean }
+) {
+  const isFirstMount = useRef(true);
+  const { set, reset, clear } = useTimeout(callback, delay);
+
+  useEffect(() => {
+    if (isFirstMount.current) {
+      if (callOnMount) {
+        callback();
+      }
+      isFirstMount.current = false;
+    }
+    reset();
+  }, [callOnMount, callback, ...deps]);
+
+  return { set, reset, clear };
+}

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -1,37 +1,46 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, DependencyList } from 'react';
 import { useTimeout } from 'hooks/useTimeout';
+import { getTimeoutOptions } from 'hooks/useTimeout/useTimeout.utils';
+import type { TimeoutOptions } from 'hooks/useTimeout/useTimeout.types';
+
+export function useDependencyTimeout(
+  callback: () => void,
+  delay: number,
+  deps: DependencyList
+): ReturnType<typeof useTimeout>;
+
+export function useDependencyTimeout(
+  callback: () => void,
+  options: TimeoutOptions,
+  deps: DependencyList
+): ReturnType<typeof useTimeout>;
 
 /**
  * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
  *
- * @param callback: 실행 할 콜백
- * @param delay: timeout delay
- * @param deps: 의존성 배열
- * @param callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정 *
- *
- * @return {ReturnType<typeof useTimeout>}
+ * @param {() => void} callback - delay 후에 실행될 함수입니다.
+ * @param {number | TimeoutOptions} options - 밀리초(ms) 단위의 지연 시간 또는 옵션 객체(delay, enabled)입니다.
+ * @param {DependencyList} deps - 의존성 배열
  *
  * @example
- * const { set, reset, clear } = useDependencyTimeout(() => console.log(something), 500, deps);
+ * useDependencyTimeout(callback, 300, [condition]);
+ *
+ * @example
+ * useDependencyTimeout(callback, { delay: 300, enabled }, [condition]);
  */
 export default function useDependencyTimeout(
   callback: () => void,
-  delay: number,
-  deps: unknown[],
-  { callOnMount }: { callOnMount: boolean }
-) {
-  const isFirstMount = useRef(true);
+  options: number | TimeoutOptions,
+  deps: DependencyList
+): ReturnType<typeof useTimeout> {
+  const { delay, enabled } = getTimeoutOptions(options);
+
   const { set, reset, clear } = useTimeout(callback, delay);
 
   useEffect(() => {
-    if (isFirstMount.current) {
-      if (callOnMount) {
-        callback();
-      }
-      isFirstMount.current = false;
-    }
+    if (delay < 0 || !enabled) return;
     reset();
-  }, [callOnMount, callback, ...deps]);
+  }, [delay, enabled, reset, ...deps]);
 
   return { set, reset, clear };
 }

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -3,12 +3,32 @@ import { useTimeout } from '../useTimeout';
 import { getTimeoutOptions } from '../useTimeout/useTimeout.utils';
 import type { TimeoutOptions } from '../useTimeout/useTimeout.types';
 
+/**
+ * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ *
+ * @param {() => void} callback - delay 후에 실행될 함수입니다.
+ * @param {number} delay - 밀리초(ms) 단위의 지연 시간
+ * @param {DependencyList} deps - 의존성 배열
+ *
+ * @example
+ * useDependencyTimeout(callback, 300, [condition]);
+ */
 export function useDependencyTimeout(
   callback: () => void,
   delay: number,
   deps: DependencyList
 ): ReturnType<typeof useTimeout>;
 
+/**
+ * @description useTimeout를 dependency 배열로 제어하는 훅입니다.
+ *
+ * @param {() => void} callback - delay 후에 실행될 함수입니다.
+ * @param {TimeoutOptions} options - timeout 옵션입니다. enabled, delay를 포함 합니다.
+ * @param {DependencyList} deps - 의존성 배열
+ *
+ * @example
+ * useDependencyTimeout(callback, { delay: 300, enabled }, [condition]);
+ */
 export function useDependencyTimeout(
   callback: () => void,
   options: TimeoutOptions,

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -1,7 +1,7 @@
 import { useEffect, DependencyList } from 'react';
-import { useTimeout } from 'hooks/useTimeout';
-import { getTimeoutOptions } from 'hooks/useTimeout/useTimeout.utils';
-import type { TimeoutOptions } from 'hooks/useTimeout/useTimeout.types';
+import { useTimeout } from '../useTimeout';
+import { getTimeoutOptions } from '../useTimeout/useTimeout.utils';
+import type { TimeoutOptions } from '../useTimeout/useTimeout.types';
 
 export function useDependencyTimeout(
   callback: () => void,

--- a/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
+++ b/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
@@ -13,11 +13,11 @@ afterEach(() => {
 });
 
 describe('useDependencyTimeout', () => {
-  it('callOnMount가 true면 마운트 시 콜백을 호출해야 합니다.', () => {
+  it('마운트 시 callOnMount가 true면 콜백을 호출해야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>
-      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: true })
+      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
     );
 
     expect(mockFn).toBeCalledTimes(1);
@@ -27,11 +27,11 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(2);
   });
 
-  it('callOnMount가 false면 마운트 시 콜백을 호출하지 않아야 합니다.', () => {
+  it('마운트 시 callOnMount가 false면 콜백을 호출하지 않아야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>
-      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
     );
 
     expect(mockFn).not.toBeCalled();
@@ -41,12 +41,12 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(1);
   });
 
-  it('의존성이 변경될 때 타임아웃을 리셋해야 합니다.', () => {
+  it('의존성이 변경되면 타임아웃이 리셋되어야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { rerender } = renderHook(
       ({ deps }) =>
-        useDependencyTimeout(mockFn, delayTime, deps, { callOnMount: false }),
+        useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, deps),
       {
         initialProps: { deps: [1] },
       }
@@ -65,11 +65,11 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(1);
   });
 
-  it('타임아웃을 해제할 수 있어야 합니다.', () => {
+  it('타임아웃을 수동으로 해제할 수 있어야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(() =>
-      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
     );
 
     vi.advanceTimersByTime(delayTime / 2);
@@ -86,12 +86,34 @@ describe('useDependencyTimeout', () => {
   it('타임아웃을 수동으로 리셋할 수 있어야 합니다.', () => {
     const mockFn = vi.fn();
 
+    const { result } = renderHook(() =>
+      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
+    );
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    act(() => {
+      result.current.reset();
+    });
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    expect(mockFn).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('enabled가 false면 타임아웃이 동작하지 않아야 합니다.', () => {
+    const mockFn = vi.fn();
+
     renderHook(() =>
-      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+      useDependencyTimeout(mockFn, { delay: delayTime, enabled: false }, [])
     );
 
     vi.advanceTimersByTime(delayTime);
 
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).not.toBeCalled();
   });
 });

--- a/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
+++ b/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useDependencyTimeout from '.';
+
+const delayTime = 1000;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useDependencyTimeout', () => {
+  it('should call callback on mount if callOnMount is true', () => {
+    const mockFn = vi.fn();
+
+    renderHook(() =>
+      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: true })
+    );
+
+    expect(mockFn).toBeCalledTimes(1);
+
+    vi.advanceTimersByTime(delayTime);
+
+    expect(mockFn).toBeCalledTimes(2);
+  });
+
+  it('should not call callback on mount if callOnMount is false', () => {
+    const mockFn = vi.fn();
+
+    renderHook(() =>
+      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+    );
+
+    expect(mockFn).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('should reset the timeout when dependencies change', () => {
+    const mockFn = vi.fn();
+
+    const { rerender } = renderHook(
+      ({ deps }) =>
+        useDependencyTimeout(mockFn, delayTime, deps, { callOnMount: false }),
+      {
+        initialProps: { deps: [1] },
+      }
+    );
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    rerender({ deps: [2] });
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    expect(mockFn).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('should allow clearing the timeout', () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+    );
+
+    vi.advanceTimersByTime(delayTime / 2);
+
+    act(() => {
+      result.current.clear();
+    });
+
+    vi.advanceTimersByTime(delayTime);
+
+    expect(mockFn).not.toBeCalled();
+  });
+
+  it('should allow manual reset of the timeout', () => {
+    const mockFn = vi.fn();
+
+    renderHook(() =>
+      useDependencyTimeout(mockFn, delayTime, [], { callOnMount: false })
+    );
+
+    vi.advanceTimersByTime(delayTime);
+
+    expect(mockFn).toBeCalledTimes(1);
+  });
+});

--- a/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
+++ b/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import useDependencyTimeout from '.';
+import { useDependencyTimeout } from '.';
 
 const delayTime = 1000;
 
@@ -20,11 +20,11 @@ describe('useDependencyTimeout', () => {
       useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
     );
 
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledTimes(0);
 
     vi.advanceTimersByTime(delayTime);
 
-    expect(mockFn).toBeCalledTimes(2);
+    expect(mockFn).toBeCalledTimes(1);
   });
 
   it('마운트 시 callOnMount가 false면 콜백을 호출하지 않아야 합니다.', () => {

--- a/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
+++ b/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
@@ -13,7 +13,7 @@ afterEach(() => {
 });
 
 describe('useDependencyTimeout', () => {
-  it('should call callback on mount if callOnMount is true', () => {
+  it('callOnMount가 true면 마운트 시 콜백을 호출해야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>
@@ -27,7 +27,7 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(2);
   });
 
-  it('should not call callback on mount if callOnMount is false', () => {
+  it('callOnMount가 false면 마운트 시 콜백을 호출하지 않아야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>
@@ -41,7 +41,7 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(1);
   });
 
-  it('should reset the timeout when dependencies change', () => {
+  it('의존성이 변경될 때 타임아웃을 리셋해야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { rerender } = renderHook(
@@ -65,7 +65,7 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).toBeCalledTimes(1);
   });
 
-  it('should allow clearing the timeout', () => {
+  it('타임아웃을 해제할 수 있어야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(() =>
@@ -83,7 +83,7 @@ describe('useDependencyTimeout', () => {
     expect(mockFn).not.toBeCalled();
   });
 
-  it('should allow manual reset of the timeout', () => {
+  it('타임아웃을 수동으로 리셋할 수 있어야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>

--- a/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
+++ b/packages/react/src/hooks/useDependencyTimeout/useDependencyTimeout.spec.tsx
@@ -13,34 +13,6 @@ afterEach(() => {
 });
 
 describe('useDependencyTimeout', () => {
-  it('마운트 시 callOnMount가 true면 콜백을 호출해야 합니다.', () => {
-    const mockFn = vi.fn();
-
-    renderHook(() =>
-      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
-    );
-
-    expect(mockFn).toBeCalledTimes(0);
-
-    vi.advanceTimersByTime(delayTime);
-
-    expect(mockFn).toBeCalledTimes(1);
-  });
-
-  it('마운트 시 callOnMount가 false면 콜백을 호출하지 않아야 합니다.', () => {
-    const mockFn = vi.fn();
-
-    renderHook(() =>
-      useDependencyTimeout(mockFn, { delay: delayTime, enabled: true }, [])
-    );
-
-    expect(mockFn).not.toBeCalled();
-
-    vi.advanceTimersByTime(delayTime);
-
-    expect(mockFn).toBeCalledTimes(1);
-  });
-
   it('의존성이 변경되면 타임아웃이 리셋되어야 합니다.', () => {
     const mockFn = vi.fn();
 

--- a/packages/react/src/hooks/useTimeout/useTimeout.spec.tsx
+++ b/packages/react/src/hooks/useTimeout/useTimeout.spec.tsx
@@ -29,7 +29,7 @@ const TestComponent = () => {
 };
 
 describe('useTimeout', () => {
-  it('should call the function after the specified delay', () => {
+  it('지정된 delay 후에 함수가 호출되어야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() => useTimeout(mockFn, { delay: delayTime }));
@@ -40,7 +40,7 @@ describe('useTimeout', () => {
     expect(mockFn).toBeCalled();
   });
 
-  it('should call the function only when enabled', () => {
+  it('활성화된 경우에만 함수가 호출되어야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { rerender } = renderHook(
@@ -62,7 +62,7 @@ describe('useTimeout', () => {
     expect(mockFn).toBeCalled();
   });
 
-  it('should call the function after being set and reset', () => {
+  it('설정 및 재설정된 후 함수가 호출되어야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(
@@ -90,7 +90,7 @@ describe('useTimeout', () => {
     expect(mockFn).toBeCalledTimes(2);
   });
 
-  it('should disable the timeout when delay is undefined', () => {
+  it('delay가 undefined일 경우 타이머가 비활성화되어야 합니다.', () => {
     const mockFn = vi.fn();
 
     renderHook(() =>
@@ -103,7 +103,7 @@ describe('useTimeout', () => {
     expect(mockFn).toBeCalled();
   });
 
-  it('should ensure the callback function always has the latest state', () => {
+  it('콜백 함수가 항상 최신 상태를 유지해야 합니다.', () => {
     renderSetup(<TestComponent />);
 
     expect(screen.getByText('0')).toBeInTheDocument();


### PR DESCRIPTION
## Overview

Issue: #372 


## 고민점

#372 에서 아래와 같은 인터페이스를 명시해주셔서 이렇게 구현했습니다.

```js
/*
  callback: 실행 할 콜백
  delay: timeout delay
  deps: 의존성 배열
  callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정
*/
useDependencyTimeout(callback, delay, deps, { callOnMount });
```

그런데 `useTimout`을 사용한 구현인만큼, `useTimeout`의 `options`도 사용할 수 있어야 하지 않을까 하는 고민이 존재했는데요.

```js
/*
  callback: 실행 할 콜백
  options: TimeoutOptions & { deps unknown }
  callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정
*/
useDependencyTimeout(callback, delay, deps, { callOnMount });
```

객체로 받는 것이 아니라 인수로 받는 경우 생각보다 인수가 많아질 수도 있다고 생각해 고민이 되었습니다.

```js
/*
  callback: 실행 할 콜백
  options: TimeoutOptions
  delay: timeout delay
  deps: 의존성 배열
  callOnMount: 최초 마운트 시에 callback 호출 할 것인지 결정
*/
useDependencyTimeout(callback, delay, deps, { callOnMount });
```

의견 주시면 감사하겠습니다. 


PS.
개인적으로 바빠서 작업이 늦어졌습니다 !!

양해해주시면 감사하겠습니다 !

추후엔 할당 받은 작업을 빠르게 구현할 수 있도록 해보겠습니다 !



## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)