### PR TITLE
feat(react): useAsyncEffect 신규 훅 추가

### DIFF
--- a/.changeset/orange-gifts-poke.md
+++ b/.changeset/orange-gifts-poke.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useAsyncEffect 신규 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useAsyncEffect.mdx
+++ b/docs/docs/react/hooks/useAsyncEffect.mdx
@@ -1,0 +1,76 @@
+import { useAsyncEffect, DebounceHandler } from '@modern-kit/react'
+import { useState } from 'react'
+
+# useAsyncEffect 
+
+일반적으로 `useEffect`에 전달하는 콜백 함수는 비동기 함수를 사용할 수 없습니다.
+
+`useAsyncEffect`는 `비동기 함수`를 `useEffect`와 함께 사용하기 위한 커스텀 훅입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useAsyncEffect/index.ts)
+
+## Interface
+```ts title="typescript"
+function useAsyncEffect(effectCallback: () => Promise<void>, deps?: DependencyList): void
+```
+
+## Usage
+```tsx title="typescript"
+import { useAsyncEffect, DebounceHandler } from '@modern-kit/react'
+
+const Example = () => {
+  const [data, setData] = useState(null)
+  const [id, setId] = useState(1);
+
+  const fetchData = async () => {
+    const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${id}`)
+    const data = await res.json()
+    setData(data)
+  }
+
+  useAsyncEffect(fetchData, [id]);
+
+  return (
+    <div>
+      {/* DebounceHandler를 활용해 버튼 클릭 이벤트를 디바운스 처리합니다. */}
+      <DebounceHandler wait={500} capture={'onClick'}>
+        <button onClick={() => setId(id + 1)}>ID Change: {id}</button>
+      </DebounceHandler>
+      <p>ID: {data?.id}</p>
+      <p>TITLE: {data?.title}</p>
+      <p>BODY: {data?.body}</p>
+    </div>
+  );
+}
+```
+
+## Example
+
+export const Example = () => {
+  const [data, setData] = useState(null)
+  const [id, setId] = useState(1);
+
+  const fetchData = async () => {
+    const res = await fetch(`https://jsonplaceholder.typicode.com/posts/${id}`)
+    const data = await res.json()
+    setData(data)
+  }
+
+  useAsyncEffect(fetchData, [id]);
+
+  return (
+    <div>
+      <DebounceHandler wait={500} capture={'onClick'}>
+        <button onClick={() => setId(id + 1)}>ID Change: {id}</button>
+      </DebounceHandler>
+      <p>ID: {data?.id}</p>
+      <p>TITLE: {data?.title}</p>
+      <p>BODY: {data?.body}</p>
+    </div>
+  );
+}
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -1,3 +1,4 @@
+export * from './useAsyncEffect';
 export * from './useAsyncProcessQueue';
 export * from './useBeforeUnload';
 export * from './useBlockPromiseMultipleClick';

--- a/packages/react/src/hooks/useAsyncEffect/index.ts
+++ b/packages/react/src/hooks/useAsyncEffect/index.ts
@@ -1,0 +1,29 @@
+import { DependencyList, useEffect } from 'react';
+
+/**
+ * @description 비동기 함수를 `useEffect`와 함께 사용하기 위한 커스텀 훅입니다.
+ *
+ * @param {() => Promise<void>} effectCallback - 실행할 비동기 함수입니다.
+ * @param {DependencyList} deps - effect를 다시 실행 할 의존성 배열입니다.
+ *
+ * @returns {void}
+ *
+ * @example
+ * useAsyncEffect(async () => {
+ *   const data = await fetchData();
+ *   setData(data);
+ * }, deps);
+ */
+export function useAsyncEffect(
+  effectCallback: () => Promise<void>,
+  deps?: DependencyList
+): void {
+  useEffect(() => {
+    const execute = async () => {
+      await effectCallback();
+    };
+
+    execute();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
+}

--- a/packages/react/src/hooks/useAsyncEffect/useAsyncEffect.spec.ts
+++ b/packages/react/src/hooks/useAsyncEffect/useAsyncEffect.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAsyncEffect } from '.';
+import { asyncNoop } from '@modern-kit/utils';
+
+describe('useAsyncEffect', () => {
+  it('마운트 시 비동기 effect가 실행되어야 한다', () => {
+    const effect = vi.fn(asyncNoop);
+
+    renderHook(() => useAsyncEffect(effect));
+
+    expect(effect).toHaveBeenCalledTimes(1);
+  });
+
+  it('의존성이 변경될 때 effect가 다시 실행되어야 한다', () => {
+    const effect = vi.fn(asyncNoop);
+
+    const { rerender } = renderHook(
+      ({ deps }) => useAsyncEffect(effect, [deps]),
+      {
+        initialProps: {
+          deps: 1,
+        },
+      }
+    );
+
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: 2 });
+
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/react/src/hooks/useDependencyTimeout/index.ts
+++ b/packages/react/src/hooks/useDependencyTimeout/index.ts
@@ -63,6 +63,7 @@ export function useDependencyTimeout(
   useEffect(() => {
     if (delay < 0 || !enabled) return;
     reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [delay, enabled, reset, ...deps]);
 
   return { set, reset, clear };


### PR DESCRIPTION
## Overview

Issue: 

일반적으로 `useEffect`에 전달하는 콜백 함수는 비동기 함수를 사용할 수 없습니다.

`useAsyncEffect`는 `비동기 함수`를 `useEffect`와 함께 사용하기 위한 커스텀 훅입니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)