### PR TITLE
feat: DeepEqual 유틸 타입 추가

### DIFF
--- a/.changeset/few-badgers-dance.md
+++ b/.changeset/few-badgers-dance.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/types': minor
+---
+
+feat(types): DeeoEqual 유틸 타입 추가 - @ssi02014

--- a/packages/types/src/DeepPartial/DeepEqual.spec.ts
+++ b/packages/types/src/DeepPartial/DeepEqual.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { DeepPartial } from '.';
+
+describe('DeepPartial', () => {
+  interface User {
+    name: string;
+    age: string;
+    address: {
+      street: string;
+      city: string;
+    };
+  }
+
+  it('DeepPartial 타입은 중첩된 객체의 모든 속성을 선택적으로 만들어줍니다.', () => {
+    const user: DeepPartial<User> = {
+      name: 'John',
+      age: '20',
+    };
+
+    expectTypeOf(user).toEqualTypeOf<{
+      name?: string;
+      age?: string;
+      address?: { street?: string; city?: string };
+    }>();
+  });
+});

--- a/packages/types/src/DeepPartial/index.ts
+++ b/packages/types/src/DeepPartial/index.ts
@@ -1,0 +1,28 @@
+/**
+ * @description 객체의 모든 속성을 선택적(optional)으로 만드는 타입
+ * 중첩된 객체의 경우에도 재귀적으로 모든 속성을 선택적으로 변환합니다.
+ *
+ * @template {Record<PropertyKey, any>} T - 변환할 객체 타입
+ * @example
+ * interface User {
+ *   name: string;
+ *   age: number;
+ *   address: {
+ *     street: string;
+ *     city: string;
+ *   };
+ * }
+ *
+ * type PartialUser = DeepPartial<User>;
+ * // {
+ * //   name?: string;
+ * //   age?: number;
+ * //   address?: {
+ * //     street?: string;
+ * //     city?: string;
+ * //   };
+ * // }
+ */
+export type DeepPartial<T extends Record<PropertyKey, any>> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Arrayable';
+export * from './DeepPartial';
 export * from './DistributiveOmit';
 export * from './ExcludeNullish';
 export * from './ExtractMapType';


### PR DESCRIPTION
## Overview

feat: DeepEqual 유틸 타입 추가

## DeepEqual
객체의 모든 속성을 선택적(optional)으로 만드는 타입
중첩된 객체의 경우에도 재귀적으로 모든 속성을 선택적으로 변환합니다.

```ts
interface User {
  name: string;
  age: number;
  address: {
    street: string;
    city: string;
  };
};

type PartialUser = DeepPartial<User>;
// {
//   name?: string;
//   age?: number;
//   address?: {
//     street?: string;
//     city?: string;
//   };
// }
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)