### PR TITLE
feat(utils): isBlob 함수 추가

### DIFF
--- a/.changeset/ninety-dolphins-decide.md
+++ b/.changeset/ninety-dolphins-decide.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/utils': minor
+---
+
+feat(utils): isBlob 함수 추가 - @ssi02014

--- a/docs/docs/utils/validator/isBlob.md
+++ b/docs/docs/utils/validator/isBlob.md
@@ -1,0 +1,28 @@
+# isBlob
+
+주어진 값이 `Blob` 타입인지 확인하고, 맞다면 인자의 타입을 `Blob`로 좁혀주는 함수입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/validator/isBlob/index.ts)
+
+## Interface
+```ts title="typescript"
+function isBlob(x: unknown): x is Blob
+```
+
+## Usage
+```ts title="typescript"
+import { isBlob } from '@modern-kit/utils';
+
+isBlob(new Blob()); // true
+isBlob(new Blob(['content'], { type: 'text/plain' })); // true
+
+isBlob('blob'); // false
+isBlob(123); // false
+isBlob({ a: 1 }); // false
+isBlob([1, 2, 3]); // false
+isBlob(null); // false
+isBlob(undefined); // false
+```

--- a/packages/utils/src/validator/index.ts
+++ b/packages/utils/src/validator/index.ts
@@ -1,5 +1,6 @@
 export * from './hasProperty';
 export * from './isArray';
+export * from './isBlob';
 export * from './isBoolean';
 export * from './isDate';
 export * from './isEqual';

--- a/packages/utils/src/validator/isBlob/index.ts
+++ b/packages/utils/src/validator/isBlob/index.ts
@@ -1,0 +1,21 @@
+/**
+ * @description 주어진 값이 `Blob` 타입인지 확인하고, 맞다면 인자의 타입을 `Blob`로 좁혀주는 함수입니다.
+ *
+ * @param {unknown} x - 확인할 값입니다.
+ * @returns {x is Blob} 값이 `Blob` 객체일 경우 `true`, 그렇지 않으면 `false`를 반환합니다.
+ *
+ * @example
+ * const blob = new Blob(["Hello, world!"], { type: "text/plain" });
+ * isBlob(blob); // true
+ *
+ * const notBlob = "Not a Blob";
+ * isBlob(notBlob); // false
+ */
+export function isBlob(x: unknown): x is Blob {
+  // Blob 타입을 지원하지 않는 경우 false를 반환
+  if (typeof Blob === 'undefined') {
+    return false;
+  }
+
+  return x instanceof Blob;
+}

--- a/packages/utils/src/validator/isBlob/isBlob.spec.ts
+++ b/packages/utils/src/validator/isBlob/isBlob.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isBlob } from '.';
+
+describe('isBlob', () => {
+  it('값이 Blob인 경우 true를 반화해야 합니다.', () => {
+    expect(isBlob(new Blob())).toBeTruthy();
+
+    const blobWithOptions = new Blob(['content'], { type: 'text/plain' });
+    expect(isBlob(blobWithOptions)).toBeTruthy();
+  });
+
+  it('값이 Blob이 아닌 경우 false를 반환해야 합니다.', () => {
+    expect(isBlob('blob')).toBeFalsy();
+    expect(isBlob(123)).toBeFalsy();
+    expect(isBlob({ a: 1 })).toBeFalsy();
+    expect(isBlob([1, 2, 3])).toBeFalsy();
+    expect(isBlob(null)).toBeFalsy();
+    expect(isBlob(undefined)).toBeFalsy();
+  });
+});

--- a/packages/utils/subPaths.mjs
+++ b/packages/utils/subPaths.mjs
@@ -174,6 +174,7 @@ export const validatorKeys = [
   'index',
   'hasProperty',
   'isArray',
+  'isBlob',
   'isBoolean',
   'isDate',
   'isEqual',


### PR DESCRIPTION
## Overview

```ts title="typescript"
import { isBlob } from '@modern-kit/utils';

isBlob(new Blob()); // true
isBlob(new Blob(['content'], { type: 'text/plain' })); // true

isBlob('blob'); // false
isBlob(123); // false
isBlob({ a: 1 }); // false
isBlob([1, 2, 3]); // false
isBlob(null); // false
isBlob(undefined); // false
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)