### PR TITLE
feat(react): useDidUpdate 신규 훅 추가

### DIFF
--- a/.changeset/shiny-walls-rush.md
+++ b/.changeset/shiny-walls-rush.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/react": minor
+---
+
+feat(react): useDidUpdate 신규 훅 추가 - @dngur9801

--- a/docs/docs/react/hooks/useDidUpdate.mdx
+++ b/docs/docs/react/hooks/useDidUpdate.mdx
@@ -1,0 +1,58 @@
+import { useDidUpdate } from '@modern-kit/react'
+import { useState } from 'react'
+
+# useDidUpdate
+
+`useDidUpdate`는 최초 마운트 시에는 실행되지 않고, 의존성 배열(`deps`)의 값이 업데이트되었을 때만 effect를 실행시키는 커스텀 훅입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useDidUpdate/index.ts)
+
+## Interface
+```ts title="typescript"
+function useDidUpdate(effect: () => void, deps: DependencyList): void
+```
+
+## Usage
+```tsx title="typescript"
+import { useDidUpdate } from '@modern-kit/react'
+
+const Example = () => {
+  const [count, setCount] = useState(0);
+  const [isUpdated, setIsUpdated] = useState(false);
+
+  useDidUpdate(() => {
+    setIsUpdated(true);
+  }, [count]);
+
+
+  return (
+    <div>
+      <button onClick={() => setCount(count + 1)}>Increment: {count}</button>
+      {isUpdated && <p>count가 변경되었습니다. {count}</p>}
+    </div>
+  );
+}
+```
+
+## Example
+
+export const Example = () => {
+  const [count, setCount] = useState(0);
+  const [isUpdated, setIsUpdated] = useState(false);
+
+  useDidUpdate(() => {
+    setIsUpdated(true);
+  }, [count]);
+
+  return (
+    <div>
+      <button onClick={() => setCount(count + 1)}>Increment: {count}</button>
+      {isUpdated && <p>count가 변경되었습니다. {count}</p>}
+    </div>
+  );
+}
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -10,6 +10,7 @@ export * from './useCycleList';
 export * from './useDebounce';
 export * from './useDebouncedInputValue';
 export * from './useDebouncedState';
+export * from './useDidUpdate';
 export * from './useDocumentTitle';
 export * from './useEventListener';
 export * from './useFileReader';

--- a/packages/react/src/hooks/useDidUpdate/index.ts
+++ b/packages/react/src/hooks/useDidUpdate/index.ts
@@ -1,19 +1,18 @@
 import { DependencyList, useEffect, useRef } from 'react';
 
 /**
- * @description 최초 마운트시에는 실행되지않고 deps값이 업데이트 되었을때 effect를 실행시키는 커스텀 훅입니다.
+ * @description 최초 마운트 시에는 실행되지 않고, 의존성 배열(`deps`)의 값이 업데이트되었을 때만 effect를 실행시키는 커스텀 훅입니다.
  *
- * @param effect 실행할 함수입니다.
- * @param deps effect를 다시 실행 할 의존성 배열입니다.
+ * @param {() => void} effect - 실행할 함수입니다.
+ * @param {DependencyList} deps - effect를 다시 실행 할 의존성 배열입니다.
  *
- * @returns void
+ * @returns {void} void
  *
  * @example
  * useDidUpdate(() => {
  *  console.log('deps가 변경되었습니다.');
- * }, [deps]);
+ * }, deps);
  */
-
 export function useDidUpdate(effect: () => void, deps: DependencyList): void {
   const isMounted = useRef(false);
 

--- a/packages/react/src/hooks/useDidUpdate/index.ts
+++ b/packages/react/src/hooks/useDidUpdate/index.ts
@@ -24,5 +24,6 @@ export function useDidUpdate(effect: () => void, deps: DependencyList): void {
     }
 
     effect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
 }

--- a/packages/react/src/hooks/useDidUpdate/index.ts
+++ b/packages/react/src/hooks/useDidUpdate/index.ts
@@ -1,0 +1,28 @@
+import { DependencyList, useEffect, useRef } from 'react';
+
+/**
+ * @description 최초 마운트시에는 실행되지않고 deps값이 업데이트 되었을때 effect를 실행시키는 커스텀 훅입니다.
+ *
+ * @param effect 실행할 함수입니다.
+ * @param deps effect를 다시 실행 할 의존성 배열입니다.
+ *
+ * @returns void
+ *
+ * @example
+ * useDidUpdate(() => {
+ *  console.log('deps가 변경되었습니다.');
+ * }, [deps]);
+ */
+
+export function useDidUpdate(effect: () => void, deps: DependencyList): void {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
+
+    effect();
+  }, deps);
+}

--- a/packages/react/src/hooks/useDidUpdate/useDidUpdate.spec.tsx
+++ b/packages/react/src/hooks/useDidUpdate/useDidUpdate.spec.tsx
@@ -5,9 +5,6 @@ import { useDidUpdate } from '.';
 describe('useDidUpdate', () => {
   it('초기 마운트 시 effect가 호출되지 않아야 합니다', () => {
     const effect = vi.fn();
-    const { rerender } = renderHook(({ deps }) => useDidUpdate(effect, deps), {
-      initialProps: { deps: [1] },
-    });
 
     expect(effect).not.toHaveBeenCalled();
   });

--- a/packages/react/src/hooks/useDidUpdate/useDidUpdate.spec.tsx
+++ b/packages/react/src/hooks/useDidUpdate/useDidUpdate.spec.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDidUpdate } from '.';
+
+describe('useDidUpdate', () => {
+  it('초기 마운트 시 effect가 호출되지 않아야 합니다', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(({ deps }) => useDidUpdate(effect, deps), {
+      initialProps: { deps: [1] },
+    });
+
+    expect(effect).not.toHaveBeenCalled();
+  });
+
+  it('의존성이 변경될 때 effect가 호출되어야 합니다', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(({ deps }) => useDidUpdate(effect, deps), {
+      initialProps: { deps: [1] },
+    });
+
+    rerender({ deps: [2] });
+    expect(effect).toHaveBeenCalledTimes(1);
+
+    rerender({ deps: [3] });
+    expect(effect).toHaveBeenCalledTimes(2);
+  });
+
+  it('의존성이 변경되지 않을 때 effect가 호출되지 않아야 합니다', () => {
+    const effect = vi.fn();
+    const { rerender } = renderHook(({ deps }) => useDidUpdate(effect, deps), {
+      initialProps: { deps: [1] },
+    });
+
+    rerender({ deps: [1] });
+    expect(effect).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Overview

Issue: #752 

<!-- Write a description of your work.  -->
최초 마운트시에는 실행되지않고 deps값이 업데이트 되었을때 effect를 실행시키는 커스텀 훅입니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)