### PR TITLE
feat(react): EventExtender 신규 컴포넌트 추가

### DIFF
--- a/.changeset/silly-poems-grow.md
+++ b/.changeset/silly-poems-grow.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): EventExtender 신규 컴포넌트 추가 - @ssi02014

--- a/docs/docs/react/components/EventExtender.mdx
+++ b/docs/docs/react/components/EventExtender.mdx
@@ -1,0 +1,171 @@
+import { useState } from 'react';
+import { EventExtender } from '@modern-kit/react';
+import { delay } from '@modern-kit/utils';
+
+# EventExtender
+
+자식 컴포넌트의 이벤트 핸들러를 확장하여 `전후 처리`를 가능하게 하는 컴포넌트입니다.
+
+기본적으로 `isAsync` 옵션은 `false`이며, `동기 이벤트`를 처리합니다.
+
+`isAsync` 옵션을 `true`로 주고, `비동기 이벤트` 를 처리 할 수 있습니다. 이를 통해 `비동기 이벤트 순서 보장`을 할 수 있습니다.
+
+단, `비동기 이벤트`를 처리 할 경우 일반적인 이벤트 호출 순서가 아닌 순서로 이벤트가 호출될 수 있습니다.
+
+이런 현상은 대표적으로 `MouseEvent`를 캡처하는 경우에 발생합니다.
+- 예를 들어, `onMouseUp` 이벤트는 `onClick` 이벤트 이전에 호출되는게 일반적이지만, 해당 컴포넌트로 `onMouseUp` 이벤트를 캡처하면 `onMouseUp` 이벤트가 `onClick` 이벤트 이후에 호출됩니다.
+- 이러한 현상은 `isAsync`가 `true`일 시 이벤트를 `await` 하기 때문입니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/components/EventExtender/index.tsx)
+
+## Interface
+```ts title="typescript"
+/**
+ * @description HTML 요소들의 태그 이름 타입 (예: "div", "span", "input" 등)
+ */
+type HTMLElementType = keyof JSX.IntrinsicElements;
+
+/**
+ * @description React.DOMAttributes<HTMLElement>에 정의된 이벤트
+ * - "on"으로 시작하는 이벤트 핸들러 이름만 포함 (예: "onClick", "onChange", "onSubmit" 등)
+ */
+type EventNames = keyof React.DOMAttributes<HTMLElement> & `on${string}`;
+
+/**
+ * @description 특정 HTML 요소의 특정 이벤트에 대한 이벤트 객체 타입을 추론하는 제네릭 타입
+ * @template K - HTML 요소 타입 (예: "button", "input" 등)
+ * @template E - 이벤트 핸들러 이름 (예: "onClick", "onChange" 등)
+ * @returns 해당 이벤트의 이벤트 객체 타입 또는 never
+ */
+type ElementEventType<
+  K extends HTMLElementType,
+  E extends EventNames
+> = JSX.IntrinsicElements[K][E] extends ((e: infer Event) => void) | undefined
+  ? Event
+  : never;
+```
+```tsx title="typescript"
+interface EventExtenderProps<K extends HTMLElementType, E extends EventNames> {
+  children: JSX.Element;
+  capture: E;
+  isAsync?: boolean; // 기본값: false
+  beforeEvent?: (e: ElementEventType<K, E>) => void | Promise<void>;
+  afterEvent?: (e: ElementEventType<K, E>) => void | Promise<void>;
+}
+
+const EventExtender: <
+  K extends keyof JSX.IntrinsicElements,
+  E extends EventNames
+>({
+  children,
+  capture,
+  isAsync,
+  beforeEvent,
+  afterEvent,
+}: EventExtenderProps<K, E>) => JSX.Element;
+```
+
+## Usage
+### 기본 사용법
+```tsx title="typescript"
+import { EventExtender } from '@modern-kit/react'
+
+const Example = () => {
+  return (
+    <EventExtender
+      capture="onClick"
+      beforeEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
+        console.log('클릭 전', e);
+      }}
+      afterEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
+        console.log('클릭 후', e);
+      }}>
+      <button onClick={(e) => console.log('클릭', e)}>Sync Button</button>
+    </EventExtender>
+  );
+};
+```
+
+export const SyncExample = () => {
+  return (
+    <>
+      <p>개발자 도구 콘솔에서 확인해주세요.</p>
+      <EventExtender
+        capture="onClick"
+        beforeEvent={(e) => {
+          console.log('클릭 전', e);
+        }}
+        afterEvent={(e) => {
+          console.log('클릭 후', e);
+        }}>
+        <button onClick={(e) => console.log('클릭', e)}>Sync Button</button>
+      </EventExtender>
+    </>
+  );
+};
+
+<SyncExample />
+
+<br />
+
+### 비동기 이벤트 처리
+```tsx title="typescript"
+import { EventExtender } from '@modern-kit/react'
+
+const Example = () => {
+  return (
+    <EventExtender
+      isAsync={true} // (*)
+      capture="onClick"
+      beforeEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
+        await delay(500);
+        console.log('클릭 전', e);
+      }}
+      afterEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
+        await delay(500);
+        console.log('클릭 후', e);
+      }}>
+      <button
+        onClick={async (e: React.MouseEvent<HTMLButtonElement>) => {
+          await delay(500);
+          console.log('클릭', e);
+        }}>
+        Async Button
+      </button>
+    </EventExtender>
+  );
+};
+```
+
+export const AsyncExample = () => {
+  return (
+    <>
+      <p>개발자 도구 콘솔에서 확인해주세요.</p>
+      <EventExtender
+        isAsync
+        capture="onClick"
+        beforeEvent={async (e) => {
+          await delay(500);
+          console.log('클릭 전', e);
+        }}
+        afterEvent={async (e) => {
+          await delay(500);
+          console.log('클릭 후', e);
+        }}>
+        <button
+          onClick={async (e) => {
+            await delay(500);
+            console.log('클릭', e);
+          }}>
+          Async Button
+        </button>
+      </EventExtender>
+    </>
+  );
+};
+
+<AsyncExample />
+

--- a/packages/react/src/components/EventExtender/EventExtender.spec.tsx
+++ b/packages/react/src/components/EventExtender/EventExtender.spec.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderSetup } from '../../_internal/test/renderSetup';
+import { screen, waitFor } from '@testing-library/react';
+import { delay } from '@modern-kit/utils';
+import { EventExtender } from '.';
+
+const DELAY = 200;
+
+beforeEach(() => {
+  // https://github.com/testing-library/user-event/issues/833#issuecomment-1725364780
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('EventExtender', () => {
+  describe('기본 동작', () => {
+    it('beforeEvent, 원래 이벤트 핸들러, afterEvent가 순서대로 호출되어야 합니다.', async () => {
+      const array: string[] = [];
+
+      const { user } = renderSetup(
+        <EventExtender
+          capture="onClick"
+          beforeEvent={() => {
+            array.push('before');
+          }}
+          afterEvent={() => {
+            array.push('after');
+          }}>
+          <button onClick={() => array.push('origin')}>Button</button>
+        </EventExtender>
+      );
+
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      expect(array).toEqual(['before', 'origin', 'after']);
+    });
+
+    it('비동기 이벤트 핸들러가 정상적으로 동작해야 합니다.', async () => {
+      const array: string[] = [];
+
+      const { user } = renderSetup(
+        <EventExtender
+          isAsync
+          capture="onClick"
+          beforeEvent={async () => {
+            await delay(DELAY);
+            array.push('before');
+          }}
+          afterEvent={async () => {
+            await delay(DELAY);
+            array.push('after');
+          }}>
+          <button
+            onClick={async () => {
+              await delay(DELAY);
+              array.push('origin');
+            }}>
+            Button
+          </button>
+        </EventExtender>
+      );
+
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      vi.advanceTimersByTime(DELAY);
+      await waitFor(() => expect(array).toEqual(['before']));
+
+      vi.advanceTimersByTime(DELAY);
+      await waitFor(() => expect(array).toEqual(['before', 'origin']));
+
+      vi.advanceTimersByTime(DELAY);
+      await waitFor(() => expect(array).toEqual(['before', 'origin', 'after']));
+    });
+
+    it('afterEvent가 정의되지 않았을 경우에도 정상적으로 동작해야 합니다.', async () => {
+      const array: string[] = [];
+
+      const { user } = renderSetup(
+        <EventExtender
+          capture="onClick"
+          beforeEvent={() => {
+            array.push('before');
+          }}>
+          <button onClick={() => array.push('origin')}>Button</button>
+        </EventExtender>
+      );
+
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      expect(array).toEqual(['before', 'origin']);
+    });
+
+    it('beforeEvent가 정의되지 않았을 경우에도 정상적으로 동작해야 합니다.', async () => {
+      const array: string[] = [];
+
+      const { user } = renderSetup(
+        <EventExtender
+          capture="onClick"
+          afterEvent={() => {
+            array.push('after');
+          }}>
+          <button onClick={() => array.push('origin')}>Button</button>
+        </EventExtender>
+      );
+
+      const button = screen.getByRole('button');
+      await user.click(button);
+
+      expect(array).toEqual(['origin', 'after']);
+    });
+  });
+});

--- a/packages/react/src/components/EventExtender/index.tsx
+++ b/packages/react/src/components/EventExtender/index.tsx
@@ -1,0 +1,146 @@
+import { isFunction } from '@modern-kit/utils';
+import React from 'react';
+
+/**
+ * @description HTML 요소들의 태그 이름 타입 (예: "div", "span", "input" 등)
+ */
+type HTMLElementType = keyof JSX.IntrinsicElements;
+
+/**
+ * @description React.DOMAttributes<HTMLElement>에 정의된 이벤트
+ * - "on"으로 시작하는 이벤트 핸들러 이름만 포함 (예: "onClick", "onChange", "onSubmit" 등)
+ */
+type EventNames = keyof React.DOMAttributes<HTMLElement> & `on${string}`;
+
+/**
+ * @description 특정 HTML 요소의 특정 이벤트에 대한 이벤트 객체 타입을 추론하는 제네릭 타입
+ * @template K - HTML 요소 타입 (예: "button", "input" 등)
+ * @template E - 이벤트 핸들러 이름 (예: "onClick", "onChange" 등)
+ * @returns 해당 이벤트의 이벤트 객체 타입 또는 never
+ * @example
+ * type InputChangeEvent = ElementEventType<"input", "onChange">; // React.ChangeEvent<HTMLInputElement>
+ * type FormSubmitEvent = ElementEventType<"form", "onSubmit">; // React.FormEvent<HTMLFormElement>
+ * type ButtonClickEvent = ElementEventType<"button", "onClick">; // React.MouseEvent<HTMLButtonElement, MouseEvent>
+ */
+type ElementEventType<
+  K extends HTMLElementType,
+  E extends EventNames
+> = JSX.IntrinsicElements[K][E] extends ((e: infer Event) => void) | undefined
+  ? Event
+  : never;
+
+interface EventExtenderProps<K extends HTMLElementType, E extends EventNames> {
+  children: JSX.Element;
+  capture: E;
+  isAsync?: boolean;
+  beforeEvent?: (e: ElementEventType<K, E>) => void | Promise<void>;
+  afterEvent?: (e: ElementEventType<K, E>) => void | Promise<void>;
+}
+
+/**
+ * @description 자식 컴포넌트의 이벤트 핸들러를 확장하여 `전후 처리`를 가능하게 하는 컴포넌트입니다.
+ *
+ * 기본적으로 `isAsync` 옵션은 `false`이며, `동기 이벤트`를 처리합니다.
+ *
+ * `isAsync` 옵션을 `true`로 주고, `비동기 이벤트` 를 처리 할 수 있습니다. 이를 통해 `비동기 이벤트 순서 보장`을 할 수 있습니다.
+ *
+ * 단, `비동기 이벤트`를 처리 할 경우 일반적인 이벤트 호출 순서가 아닌 순서로 이벤트가 호출될 수 있습니다.
+ *
+ * 이런 현상은 대표적으로 `MouseEvent`를 캡처하는 경우에 발생합니다.
+ * - 예를 들어, `onMouseUp` 이벤트는 `onClick` 이벤트 이전에 호출되는게 일반적이지만, 해당 컴포넌트로 `onMouseUp` 이벤트를 캡처하면 `onMouseUp` 이벤트가 `onClick` 이벤트 이후에 호출됩니다.
+ * - 이러한 현상은 `isAsync`가 `true`일 시 이벤트를 `await` 하기 때문입니다.
+ *
+ * @template K - HTML 요소 타입 (예: "button", "input" 등)
+ * @template E - 이벤트 핸들러 이름 (예: "onClick", "onChange" 등)
+ * @param {EventExtenderProps<K, E>} props - 컴포넌트 속성
+ * @param {JSX.Element} props.children - 단일 자식 컴포넌트 (React 엘리먼트)
+ * @param {E} props.capture - 확장하고자 하는 이벤트 핸들러 이름
+ * @param {boolean} [props.isAsync=false] - 이벤트 동기 여부
+ * @param {(e: ElementEventType<K, E>) => void | Promise<void>} [props.beforeEvent] - 이벤트 발생 전 실행할 함수, 비동기 함수 허용
+ * @param {(e: ElementEventType<K, E>) => void | Promise<void>} [props.afterEvent] - 이벤트 발생 후 실행할 함수, 비동기 함수 허용
+ * @returns {JSX.Element} 이벤트가 확장된 자식 컴포넌트
+ *
+ * @example
+ * ```tsx
+ * // 기본 사용법
+ * <EventExtender
+ *   capture="onClick"
+ *   beforeEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
+ *     console.log('클릭 전', e);
+ *   }}
+ *   afterEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
+ *     console.log('클릭 후', e);
+ *   }}
+ * >
+ *   <button onClick={(e) => console.log('클릭', e)}>
+ *     Button
+ *   </button>
+ * </EventExtender>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // 비동기 함수를 사용할 수 있습니다.
+ * <EventExtender
+ *   isAsync={true} // (*)
+ *   capture="onClick"
+ *   beforeEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
+ *     console.log('클릭 전', e);
+ *     await asyncFunction();
+ *   }}
+ *   afterEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
+ *     console.log('클릭 후', e);
+ *     await asyncFunction();
+ *   }}
+ * >
+ *   <button onClick={(e: React.MouseEvent<HTMLButtonElement>) => console.log('클릭', e)}>
+ *     Button
+ *   </button>
+ * </EventExtender>
+ * ```
+ */
+export const EventExtender = <K extends HTMLElementType, E extends EventNames>({
+  children,
+  capture,
+  isAsync = false,
+  beforeEvent,
+  afterEvent,
+}: EventExtenderProps<K, E>): JSX.Element => {
+  const child = React.Children.only(children);
+
+  const asyncEvent = async (eventType: ElementEventType<K, E>) => {
+    if (beforeEvent) {
+      await beforeEvent(eventType);
+    }
+
+    const originEvent = child.props[capture];
+    if (isFunction(originEvent)) {
+      await originEvent(eventType);
+    }
+
+    if (afterEvent) {
+      await afterEvent(eventType);
+    }
+  };
+
+  const syncEvent = (eventType: ElementEventType<K, E>) => {
+    if (beforeEvent) {
+      beforeEvent(eventType);
+    }
+
+    const originEvent = child.props[capture];
+    if (isFunction(originEvent)) {
+      originEvent(eventType);
+    }
+
+    if (afterEvent) {
+      afterEvent(eventType);
+    }
+  };
+
+  const enhancedProps = {
+    [capture]: isAsync ? asyncEvent : syncEvent,
+  };
+
+  return React.cloneElement(child, enhancedProps);
+};

--- a/packages/react/src/components/FallbackLazyImage/index.tsx
+++ b/packages/react/src/components/FallbackLazyImage/index.tsx
@@ -19,16 +19,7 @@ export const FallbackLazyImage = forwardRef<
   FallbackLazyImageProps
 >(
   (
-    {
-      width,
-      height,
-      fallback,
-      className,
-      style,
-      duration = '0.2s',
-      onLoad,
-      ...restProps
-    },
+    { width, height, fallback, style, duration = '0.2s', onLoad, ...restProps },
     ref
   ) => {
     const [isLoaded, setIsLoaded] = useState(false);
@@ -64,12 +55,8 @@ export const FallbackLazyImage = forwardRef<
       [onLoad]
     );
 
-    const customClassName = className
-      ? `lazy-image-wrapper ${className}`
-      : 'lazy-image-wrapper';
-
     return (
-      <div className={customClassName} style={wrapperStyle}>
+      <div style={wrapperStyle}>
         {isRenderFallback && fallback}
         <LazyImage
           ref={ref}

--- a/packages/react/src/components/SwitchCase/SwitchCase.test.tsx
+++ b/packages/react/src/components/SwitchCase/SwitchCase.test.tsx
@@ -3,7 +3,7 @@ import { screen } from '@testing-library/react';
 import { renderSetup } from '../../_internal/test/renderSetup';
 import { SwitchCase } from '.';
 
-const TestComponent = ({ value }: { value: string }) => {
+const TestComponent = ({ value }: { value: string | null | undefined }) => {
   return (
     <SwitchCase
       value={value}
@@ -39,5 +39,11 @@ describe('SwitchCase', () => {
 
     expect(screen.queryByText('A')).not.toBeInTheDocument();
     expect(screen.queryByText('B')).not.toBeInTheDocument();
+  });
+
+  it(`value가 null일 때 'Default'가 렌더링되어야 합니다.`, () => {
+    renderSetup(<TestComponent value={null} />);
+
+    expect(screen.getByText('Default')).toBeInTheDocument();
   });
 });

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './ClientGate';
 export * from './Mounted';
 export * from './DebounceHandler';
 export * from './Delay';
+export * from './EventExtender';
 export * from './FallbackLazyImage';
 export * from './IfElse';
 export * from './InfiniteScroll';

--- a/packages/react/src/hooks/useMediaQuery/useMediaQuery.spec.ts
+++ b/packages/react/src/hooks/useMediaQuery/useMediaQuery.spec.ts
@@ -38,4 +38,14 @@ describe('useMediaQuery', () => {
 
     expect(result.current).toBe(false);
   });
+
+  it('defaultValue가 제공되면, 클라이언트 환경이 아닐 때 defaultValue를 반환해야 합니다', () => {
+    vi.spyOn(ModernKitUtils, 'isClient').mockReturnValue(false);
+
+    const { result } = renderHook(() =>
+      useMediaQuery('(min-width: 600px)', true)
+    );
+
+    expect(result.current).toBe(true);
+  });
 });

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
         'src/**/*.utils.ts',
         'src/hooks/useClipboard',
         'src/hooks/useResizeObserver',
+        'build.utils.mjs',
         ...coverageConfigDefaults.exclude,
       ],
     },


### PR DESCRIPTION
## Overview

자식 컴포넌트의 이벤트 핸들러를 확장하여 `전후 처리`를 가능하게 하는 컴포넌트입니다.

기본적으로 `isAsync` 옵션은 `false`이며, `동기 이벤트`를 처리합니다.

`isAsync` 옵션을 `true`로 주고, `비동기 이벤트` 를 처리 할 수 있습니다. 이를 통해 `비동기 이벤트 순서 보장`을 할 수 있습니다.

단, `비동기 이벤트`를 처리 할 경우 일반적인 이벤트 호출 순서가 아닌 순서로 이벤트가 호출될 수 있습니다.

이런 현상은 대표적으로 `MouseEvent`를 캡처하는 경우에 발생합니다.
- 예를 들어, `onMouseUp` 이벤트는 `onClick` 이벤트 이전에 호출되는게 일반적이지만, 해당 컴포넌트로 `onMouseUp` 이벤트를 캡처하면 `onMouseUp` 이벤트가 `onClick` 이벤트 이후에 호출됩니다.
- 이러한 현상은 `isAsync`가 `true`일 시 이벤트를 `await` 하기 때문입니다.

```tsx
// 기본 사용법
<EventExtender
   capture="onClick"
   beforeEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
     console.log('클릭 전', e);
   }}
   afterEvent={(e: React.MouseEvent<HTMLButtonElement>) => {
     console.log('클릭 후', e);
   }}
 >
   <button onClick={(e) => console.log('클릭', e)}>
     Sync  Button
   </button>
 </EventExtender>
```
```tsx
// 비동기 함수를 사용할 수 있습니다.
<EventExtender
   isAsync={true} // (*)
   capture="onClick"
   beforeEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
     console.log('클릭 전', e);
     await asyncFunction();
   }}
   afterEvent={async (e: React.MouseEvent<HTMLButtonElement>) => {
     console.log('클릭 후', e);
     await asyncFunction();
   }}
 >
   <button onClick={(e: React.MouseEvent<HTMLButtonElement>) => console.log('클릭', e)}>
     Button
   </button>
 </EventExtender>
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)