### PR TITLE
feat(utils): retry 함수 추가

### DIFF
--- a/.changeset/thick-keys-collect.md
+++ b/.changeset/thick-keys-collect.md
@@ -1,0 +1,5 @@
+---
+"@modern-kit/utils": minor
+---
+
+feat(utils): retry 함수 추가 - @dngur9801

--- a/docs/docs/utils/common/retry.md
+++ b/docs/docs/utils/common/retry.md
@@ -2,7 +2,7 @@
 
 Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수입니다.
 
-재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다.
+재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다. AbortSignal을 전달하여 재시도 작업을 중단할 수 있습니다.
 
 ## Code
 [🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/common/retry/index.ts)
@@ -11,8 +11,8 @@ Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수
 ## Interface
 ```ts title="typescript"
 function retry<T>(func: () => Promise<T>): Promise<T>;
-function retry<T>(func: () => Promise<T>, retry: number): Promise<T>;
-function retry<T>(func: () => Promise<T>, { retry, delay, signal }: RetryOptions): Promise<T>;
+function retry<T>(func: () => Promise<T>, count: number): Promise<T>;
+function retry<T>(func: () => Promise<T>, { count, delay, signal }: RetryOptions): Promise<T>;
 ```
 
 ## Usage
@@ -23,10 +23,10 @@ import { retry } from '@modern-kit/utils';
 const data = await retry(fetchData, 5);
 
 // fetchData 함수가 실패할 경우 1초 간격으로 최대 5번 재시도합니다.
-const data = await retry(fetchData, { retry: 5, delay: 1000 });
+const data = await retry(fetchData, { count: 5, delay: 1000 });
 
 const controller = new AbortController();
 
 // controller.abort()가 호출되면 재시도 작업이 중단됩니다.
-const data = await retry(fetchData, { retry: 5, controller.signal });
+const data = await retry(fetchData, { count: 5, controller.signal });
 ```

--- a/docs/docs/utils/common/retry.md
+++ b/docs/docs/utils/common/retry.md
@@ -11,7 +11,7 @@ Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수
 ## Interface
 ```ts title="typescript"
 function retry<T>(func: () => Promise<T>): Promise<T>;
-function retry<T>(func: () => Promise<T>, count: number): Promise<T>;
+function retry<T>(func: () => Promise<T>, count: number = 3): Promise<T>;
 function retry<T>(func: () => Promise<T>, { count, delay, signal }: RetryOptions): Promise<T>;
 ```
 

--- a/docs/docs/utils/common/retry.md
+++ b/docs/docs/utils/common/retry.md
@@ -1,0 +1,32 @@
+# retry
+
+Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수입니다.
+
+재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다.
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/utils/src/common/retry/index.ts)
+
+
+## Interface
+```ts title="typescript"
+function retry<T>(func: () => Promise<T>): Promise<T>;
+function retry<T>(func: () => Promise<T>, retry: number): Promise<T>;
+function retry<T>(func: () => Promise<T>, { retry, delay, signal }: RetryOptions): Promise<T>;
+```
+
+## Usage
+```ts title="typescript"
+import { retry } from '@modern-kit/utils';
+
+// fetchData 함수가 성공할 때까지 최대 5번 재시도합니다.
+const data = await retry(fetchData, 5);
+
+// fetchData 함수가 실패할 경우 1초 간격으로 최대 5번 재시도합니다.
+const data = await retry(fetchData, { retry: 5, delay: 1000 });
+
+const controller = new AbortController();
+
+// controller.abort()가 호출되면 재시도 작업이 중단됩니다.
+const data = await retry(fetchData, { retry: 5, controller.signal });
+```

--- a/packages/utils/src/common/index.ts
+++ b/packages/utils/src/common/index.ts
@@ -11,4 +11,5 @@ export * from './noop';
 export * from './once';
 export * from './parseJSON';
 export * from './pickFalsy';
+export * from './retry';
 export * from './wrapInArray';

--- a/packages/utils/src/common/retry/index.ts
+++ b/packages/utils/src/common/retry/index.ts
@@ -1,0 +1,68 @@
+import { delay as delayFn } from '../delay';
+
+interface RetryOptions {
+  retry?: number;
+  delay?: number;
+  signal?: AbortSignal | undefined;
+}
+
+const DEFAULT_RETRY = 3;
+const DEFAULT_DELAY = 0;
+
+/**
+ * @description Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수입니다.
+ *
+ * 재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다.
+ *
+ * @template T - Promise가 반환하는 값의 타입입니다.
+ * @param {() => Promise<T>} func - Promise를 반환하는 함수입니다.
+ * @param {number | RetryOptions} options - 재시도 횟수와 재시도 사이 간격을 설정합니다.
+ * @returns {Promise<T>} - Promise를 반환하는 함수의 결과를 반환합니다.
+ *
+ * @example
+ * const data = await retry(fetchData, 5);
+ * // fetchData 함수가 성공할 때까지 최대 5번 재시도합니다.
+ *
+ * const data = await retry(fetchData, { retry: 5, delay: 1000 });
+ * // fetchData 함수가 실패할 경우 1초 간격으로 최대 5번 재시도합니다.
+ *
+ * const controller = new AbortController();
+ *
+ * const data = await retry(fetchData, { retry: 5, controller.signal });
+ * // controller.abort()가 호출되면 재시도 작업이 중단됩니다.
+ */
+
+export async function retry<T>(
+  func: () => Promise<T>,
+  options?: number | RetryOptions
+): Promise<T> {
+  let retry: number;
+  let delay: number;
+  let signal: AbortSignal | undefined;
+
+  if (typeof options === 'number') {
+    retry = options;
+    delay = DEFAULT_DELAY;
+  } else {
+    retry = options?.retry ?? DEFAULT_RETRY;
+    delay = options?.delay ?? DEFAULT_DELAY;
+    signal = options?.signal;
+  }
+
+  let error;
+
+  for (let i = 0; i < retry; i++) {
+    if (signal?.aborted) {
+      throw new Error('aborted로 인해 재시도 작업이 중단되었습니다.');
+    }
+
+    try {
+      return await func();
+    } catch (err) {
+      error = err;
+      await delayFn(delay);
+    }
+  }
+
+  throw error;
+}

--- a/packages/utils/src/common/retry/index.ts
+++ b/packages/utils/src/common/retry/index.ts
@@ -1,57 +1,120 @@
+import { isNumber } from '../../validator/isNumber';
 import { delay as delayFn } from '../delay';
 
 interface RetryOptions {
-  retry?: number;
+  count?: number;
   delay?: number;
-  signal?: AbortSignal | undefined;
+  signal?: AbortSignal;
 }
 
 const DEFAULT_RETRY = 3;
 const DEFAULT_DELAY = 0;
 
+const getRetryOptions = (options?: number | RetryOptions) => {
+  if (isNumber(options)) {
+    return { count: options, delay: DEFAULT_DELAY, signal: undefined };
+  }
+
+  return {
+    count: options?.count ?? DEFAULT_RETRY,
+    delay: options?.delay ?? DEFAULT_DELAY,
+    signal: options?.signal,
+  };
+};
+
 /**
- * @description Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수입니다.
- *
- * 재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다.
+ * @description Promise를 반환하는 함수가 실패 시 성공 할 때까지 최대 3회 재시도합니다.
  *
  * @template T - Promise가 반환하는 값의 타입입니다.
  * @param {() => Promise<T>} func - Promise를 반환하는 함수입니다.
- * @param {number | RetryOptions} options - 재시도 횟수와 재시도 사이 간격을 설정합니다.
+ * @returns {Promise<T>} - Promise를 반환하는 함수의 결과를 반환합니다.
+ *
+ * @example
+ * const data = await retry(fetchData);
+ * // fetchData 함수가 실패할 경우 최대 3회 재시도합니다.
+ */
+export async function retry<T>(func: () => Promise<T>): Promise<T>;
+
+/**
+ * @description Promise를 반환하는 함수가 실패 시 성공 할 때까지 주어진 횟수만큼 재시도합니다.
+ *
+ * @template T - Promise가 반환하는 값의 타입입니다.
+ * @param {() => Promise<T>} func - Promise를 반환하는 함수입니다.
+ * @param {number} count - 재시도 횟수입니다.
  * @returns {Promise<T>} - Promise를 반환하는 함수의 결과를 반환합니다.
  *
  * @example
  * const data = await retry(fetchData, 5);
- * // fetchData 함수가 성공할 때까지 최대 5번 재시도합니다.
+ * // fetchData 함수가 실패할 경우 최대 5회 재시도합니다.
+ */
+export async function retry<T>(
+  func: () => Promise<T>,
+  count: number
+): Promise<T>;
+
+/**
+ * @description Promise를 반환하는 함수가 실패 시 성공 할 때까지 주어진 횟수만큼 재시도합니다.
  *
- * const data = await retry(fetchData, { retry: 5, delay: 1000 });
- * // fetchData 함수가 실패할 경우 1초 간격으로 최대 5번 재시도합니다.
+ * 재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다. AbortSignal을 전달하여 재시도 작업을 중단할 수 있습니다.
  *
+ * @template T - Promise가 반환하는 값의 타입입니다.
+ * @param {() => Promise<T>} func - Promise를 반환하는 함수입니다.
+ * @param {RetryOptions} options - 재시도 횟수와 재시도 사이 간격을 설정하는 옵션 객체입니다.
+ * @param {number} [options.delay=0] - 재시도 사이 간격을 설정합니다.
+ * @param {number} [options.count=3] - 재시도 횟수를 설정합니다.
+ * @param {AbortSignal} [options.signal] - 재시도 작업을 중단할 수 있는 AbortSignal을 설정합니다.
+ * @returns {Promise<T>} - Promise를 반환하는 함수의 결과를 반환합니다.
+ *
+ * @example
+ * const data = await retry(fetchData, { count: 5, delay: 1000 });
+ * // fetchData 함수가 실패할 경우 1초 간격으로 최대 5회 재시도합니다.
+ *
+ * @example
  * const controller = new AbortController();
  *
- * const data = await retry(fetchData, { retry: 5, controller.signal });
+ * const data = await retry(fetchData, { count: 5, controller.signal });
  * // controller.abort()가 호출되면 재시도 작업이 중단됩니다.
  */
+export async function retry<T>(
+  func: () => Promise<T>,
+  options: RetryOptions
+): Promise<T>;
 
+/**
+ * @description Promise를 반환하는 함수가 실패 시 성공 할 때까지 주어진 횟수만큼 재시도합니다.
+ *
+ * 재시도 횟수와 재시도 사이 간격을 설정할 수 있습니다. AbortSignal을 전달하여 재시도 작업을 중단할 수 있습니다.
+ *
+ * @template T - Promise가 반환하는 값의 타입입니다.
+ * @param {() => Promise<T>} func - Promise를 반환하는 함수입니다.
+ * @param {number | RetryOptions} options - 재시도 횟수와 재시도 사이 간격을 설정하는 옵션 객체입니다.
+ * @returns {Promise<T>} - Promise를 반환하는 함수의 결과를 반환합니다.
+ *
+ * @example
+ * const data = await retry(fetchData);
+ * // fetchData 함수가 실패할 경우 최대 3회 재시도합니다.
+ *
+ * @example
+ * const data = await retry(fetchData, 5);
+ * // fetchData 함수가 실패할 경우 최대 5회 재시도합니다.
+ *
+ * @example
+ * const data = await retry(fetchData, { count: 5, delay: 1000 });
+ * // fetchData 함수가 실패할 경우 1초 간격으로 최대 5회 재시도합니다.
+ *
+ * @example
+ * const data = await retry(fetchData, { count: 5, controller.signal });
+ * // controller.abort()가 호출되면 재시도 작업이 중단됩니다.
+ */
 export async function retry<T>(
   func: () => Promise<T>,
   options?: number | RetryOptions
 ): Promise<T> {
-  let retry: number;
-  let delay: number;
-  let signal: AbortSignal | undefined;
-
-  if (typeof options === 'number') {
-    retry = options;
-    delay = DEFAULT_DELAY;
-  } else {
-    retry = options?.retry ?? DEFAULT_RETRY;
-    delay = options?.delay ?? DEFAULT_DELAY;
-    signal = options?.signal;
-  }
+  const { count, delay, signal } = getRetryOptions(options);
 
   let error;
 
-  for (let i = 0; i < retry; i++) {
+  for (let i = 0; i < count; i++) {
     if (signal?.aborted) {
       throw new Error('aborted로 인해 재시도 작업이 중단되었습니다.');
     }

--- a/packages/utils/src/common/retry/retry.spec.ts
+++ b/packages/utils/src/common/retry/retry.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { retry } from '.';
+
+describe('retry', () => {
+  it('지정된 retry만큼 다시 시도하고 결국 해결해야 합니다.', async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('failure'))
+      .mockRejectedValueOnce(new Error('failure'))
+      .mockResolvedValue('success');
+
+    const result = await retry(mockFn, 3);
+
+    expect(result).toBe('success');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('지정된 retry만큼 다시 시도후 결국 실패한다면 error를 throw 해야합니다.', async () => {
+    const mockFn = vi.fn().mockRejectedValue(new Error('failure'));
+
+    await expect(retry(mockFn, 3)).rejects.toThrow('failure');
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('지정된 delay만큼 시간을 지연하고 다시 시도해야 합니다.', async () => {
+    const mockFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('failure'))
+      .mockRejectedValueOnce(new Error('failure'))
+      .mockResolvedValue('success');
+
+    const start = Date.now();
+    const result = await retry(mockFn, { retry: 3, delay: 100 });
+    const end = Date.now();
+
+    expect(result).toBe('success');
+    expect(end - start).toBeGreaterThanOrEqual(200);
+    expect(mockFn).toHaveBeenCalledTimes(3);
+  });
+
+  it('지정된 signal로 중단되어야 합니다.', async () => {
+    const mockFn = vi.fn().mockRejectedValue(new Error('failure'));
+    const controller = new AbortController();
+
+    controller.abort();
+
+    await expect(
+      retry(mockFn, { retry: 3, signal: controller.signal })
+    ).rejects.toThrow('aborted로 인해 재시도 작업이 중단되었습니다.');
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+});

--- a/packages/utils/src/common/retry/retry.spec.ts
+++ b/packages/utils/src/common/retry/retry.spec.ts
@@ -15,7 +15,7 @@ describe('retry', () => {
     expect(mockFn).toHaveBeenCalledTimes(3);
   });
 
-  it('지정된 retry만큼 다시 시도후 결국 실패한다면 error를 throw 해야합니다.', async () => {
+  it('지정된 count만큼 다시 시도후 결국 실패한다면 error를 throw 해야합니다.', async () => {
     const mockFn = vi.fn().mockRejectedValue(new Error('failure'));
 
     await expect(retry(mockFn, 3)).rejects.toThrow('failure');
@@ -30,7 +30,7 @@ describe('retry', () => {
       .mockResolvedValue('success');
 
     const start = Date.now();
-    const result = await retry(mockFn, { retry: 3, delay: 100 });
+    const result = await retry(mockFn, { count: 3, delay: 100 });
     const end = Date.now();
 
     expect(result).toBe('success');
@@ -45,7 +45,7 @@ describe('retry', () => {
     controller.abort();
 
     await expect(
-      retry(mockFn, { retry: 3, signal: controller.signal })
+      retry(mockFn, { count: 3, signal: controller.signal })
     ).rejects.toThrow('aborted로 인해 재시도 작업이 중단되었습니다.');
     expect(mockFn).toHaveBeenCalledTimes(0);
   });


### PR DESCRIPTION
## Overview

Issue: #773 

<!-- Write a description of your work.  -->

Promise를 반환하는 함수가 성공할 때까지 다시 시도하는 함수입니다.

### 논의사항
retry함수 구현중 논의하고싶은 내용이 있어서 말씀드립니다!
1. retry 함수와 count 역할을하는 retry 인자값의 네이밍이 중복되는데 가독성 측면에서 혼란을 주지 않는지
2. retry 인자값이 전달되지 않았을 경우의 default값 (현재는 3입니다.)

이외에도 보완사항이 있을 경우 편하게 말씀 주시면 감사드리겠습니다. 🙏


## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)