### PR TITLE
feat(react): useDropZone 신규 훅 추가

### DIFF
--- a/.changeset/old-pants-remain.md
+++ b/.changeset/old-pants-remain.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useDropZone 신규 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useDropZone.mdx
+++ b/docs/docs/react/hooks/useDropZone.mdx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 # useDropZone
 
+`드래그 앤 드롭 이벤트`를 처리하여 `파일`을 수신할 수 있는 영역을 생성하는 커스텀 훅입니다.
 
 <br />
 

--- a/docs/docs/react/hooks/useDropZone.mdx
+++ b/docs/docs/react/hooks/useDropZone.mdx
@@ -1,0 +1,94 @@
+import { useDropZone } from '@modern-kit/react';
+import { useState } from 'react';
+
+# useDropZone
+
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useDropZone/index.ts)
+
+## Interface
+```ts title="typescript"
+const useDropZone: <T extends HTMLElement>(onDrop: (files: File[]) => void) => {
+  ref: React.RefObject<T>;
+  isDragOver: boolean;
+}
+```
+
+## Usage
+```tsx title="typescript"
+import { useState } from 'react';
+import { useDropZone } from '@modern-kit/react';
+
+const Example = () => {
+  const [fileNameList, setFileNameList] = useState<string[]>([]);
+
+  const { ref, isDragOver } = useDropZone((files) => {
+    console.log('files', files);
+    setFileNameList(files.map((file) => file.name));
+  });
+
+  const wrapperStyle = {
+    width: '400px',
+    height: '200px',
+    border: '1px solid #000',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+
+  return (
+    <div>
+      <div ref={ref} style={wrapperStyle}>
+        <p>DropZone</p>
+        <p>isDragOver: {`${isDragOver}`}</p>
+      </div>
+      <ul>
+        {fileNameList.map((fileName, index) => (
+          <li key={`${fileName}-${index}`}>{fileName}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const [fileNameList, setFileNameList] = useState([]);
+
+  const { ref, isDragOver } = useDropZone((files) => {
+    console.log('files', files);
+    setFileNameList(files.map((file) => file.name));
+  });
+
+  const wrapperStyle = {
+    width: '400px',
+    height: '200px',
+    border: '1px solid #000',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  }
+
+  return (
+    <div>
+      <div ref={ref} style={wrapperStyle}>
+        <p>DropZone</p>
+        <p>isDragOver: {`${isDragOver}`}</p>
+      </div>
+      <ul>
+        {fileNameList.map((fileName, index) => (
+          <li key={`${fileName}-${index}`}>{fileName}</li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -12,6 +12,7 @@ export * from './useDebouncedInputValue';
 export * from './useDebouncedState';
 export * from './useDidUpdate';
 export * from './useDocumentTitle';
+export * from './useDropZone';
 export * from './useEventListener';
 export * from './useFileReader';
 export * from './useFocus';

--- a/packages/react/src/hooks/useDropZone/index.ts
+++ b/packages/react/src/hooks/useDropZone/index.ts
@@ -3,7 +3,7 @@ import { usePreservedCallback } from '../usePreservedCallback';
 import { RefObject, useCallback, useRef, useState } from 'react';
 
 /**
- * @description 드래그 앤 드롭으로 파일을 업로드할 수 있는 영역을 생성하는 커스텀 훅입니다.
+ * @description `드래그 앤 드롭 이벤트`를 처리하여 `파일`을 수신할 수 있는 영역을 생성하는 커스텀 훅입니다.
  *
  * @template T - HTML 엘리먼트 타입을 지정합니다.
  * @param {(files: File[]) => void} onDrop - 파일이 드롭되었을 때 호출되는 콜백 함수입니다.

--- a/packages/react/src/hooks/useDropZone/index.ts
+++ b/packages/react/src/hooks/useDropZone/index.ts
@@ -1,0 +1,79 @@
+import { useEventListener } from '../useEventListener';
+import { usePreservedCallback } from '../usePreservedCallback';
+import { RefObject, useCallback, useRef, useState } from 'react';
+
+/**
+ * @description 드래그 앤 드롭으로 파일을 업로드할 수 있는 영역을 생성하는 커스텀 훅입니다.
+ *
+ * @template T - HTML 엘리먼트 타입을 지정합니다.
+ * @param {(files: File[]) => void} onDrop - 파일이 드롭되었을 때 호출되는 콜백 함수입니다.
+ * 드롭된 파일들의 배열을 인자로 받습니다.
+ *
+ * @returns {{
+ *   ref: RefObject<T>;
+ *   isDragOver: boolean;
+ * }} `ref`와 `isDragOver`를 포함한 객체를 반환합니다.
+ * - `ref`: 드롭 영역으로 사용할 대상 요소의 참조입니다.
+ * - `isDragOver`: 드래그한 파일이 드롭 영역 위에 있는지 여부를 나타내는 불리언 값입니다.
+ *
+ * @example
+ * ```tsx
+ * const { ref, isDragOver } = useDropZone<HTMLDivElement>((files) => {
+ *   console.log('Dropped files:', files);
+ * });
+ *
+ * <div ref={ref}>
+ *   DropZone
+ * </div>
+ * ```
+ */
+export const useDropZone = <T extends HTMLElement>(
+  onDrop: (files: File[]) => void
+): {
+  ref: RefObject<T>;
+  isDragOver: boolean;
+} => {
+  const ref = useRef<T>(null);
+  const counter = useRef(0);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const preservedDropCallback = usePreservedCallback(onDrop);
+
+  const handleDragOver = useCallback((e: DragEvent) => {
+    e.preventDefault();
+  }, []);
+
+  const handleDragEnter = useCallback((e: DragEvent) => {
+    e.preventDefault();
+
+    counter.current += 1;
+    setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+
+    counter.current -= 1;
+    if (counter.current === 0) {
+      setIsDragOver(false);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent) => {
+      e.preventDefault();
+      setIsDragOver(false);
+
+      const files = e.dataTransfer?.files;
+      preservedDropCallback(Array.from(files || []));
+    },
+    [preservedDropCallback]
+  );
+
+  useEventListener(ref, 'dragover', handleDragOver);
+  useEventListener(ref, 'dragenter', handleDragEnter);
+  useEventListener(ref, 'dragleave', handleDragLeave);
+  useEventListener(ref, 'drop', handleDrop);
+
+  return { ref, isDragOver };
+};

--- a/packages/react/src/hooks/useDropZone/useDropZone.spec.tsx
+++ b/packages/react/src/hooks/useDropZone/useDropZone.spec.tsx
@@ -1,0 +1,82 @@
+import { renderHook, screen, waitFor } from '@testing-library/react';
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import { useDropZone } from '.';
+import { renderSetup } from '../../_internal/test/renderSetup';
+
+const TestComponent = ({ onDrop }: { onDrop: (file: File[]) => void }) => {
+  const { ref, isDragOver } = useDropZone<HTMLDivElement>(onDrop);
+
+  return (
+    <>
+      <div ref={ref} role="dropZone">
+        DropZone
+      </div>
+      <div role={'isDragOver'}>{`${isDragOver}`}</div>
+    </>
+  );
+};
+describe('useDropZone', () => {
+  const mockOnDrop = vi.fn();
+
+  beforeEach(() => {
+    mockOnDrop.mockClear();
+  });
+
+  it('초기 상태에서는 isDragOver가 false여야 합니다', () => {
+    const { result } = renderHook(() => useDropZone(mockOnDrop));
+    expect(result.current.isDragOver).toBeFalsy();
+  });
+
+  it('dragenter 이벤트 발생 시 isDragOver가 true로, dragleave 이벤트 발생 시 false로 변경되어야 합니다', async () => {
+    renderSetup(<TestComponent onDrop={vi.fn()} />);
+
+    const dropZone = screen.getByRole('dropZone');
+
+    await waitFor(() => {
+      const dragEnterEvent = new Event('dragenter');
+      dropZone.dispatchEvent(dragEnterEvent);
+    });
+
+    expect(screen.getByRole('isDragOver')).toHaveTextContent('true');
+
+    await waitFor(() => {
+      const dragLeaveEvent = new Event('dragleave');
+      dropZone.dispatchEvent(dragLeaveEvent);
+    });
+
+    expect(screen.getByRole('isDragOver')).toHaveTextContent('false');
+  });
+
+  it('파일을 Drop했을 때 onDrop 콜백이 호출되어야 합니다.', async () => {
+    const mockFileList: File[] = [];
+    const file1 = new File(['text1.text'], 'text1.text');
+    const file2 = new File(['text2.text'], 'text2.text');
+    const files = [file1, file2];
+
+    renderSetup(
+      <TestComponent
+        onDrop={(fileList) => {
+          mockFileList.push(...fileList);
+        }}
+      />
+    );
+    const dropZone = screen.getByRole('dropZone');
+
+    await waitFor(() => {
+      const dropEvent = new Event('drop');
+
+      Object.defineProperty(dropEvent, 'dataTransfer', {
+        value: { files },
+      });
+      dropZone.dispatchEvent(dropEvent);
+    });
+
+    expect(mockFileList).toHaveLength(2);
+
+    expect(mockFileList[0]).toBe(file1);
+    expect(mockFileList[0].name).toBe('text1.text');
+
+    expect(mockFileList[1]).toBe(file2);
+    expect(mockFileList[1].name).toBe('text2.text');
+  });
+});

--- a/packages/react/src/hooks/useVisibilityChange/index.ts
+++ b/packages/react/src/hooks/useVisibilityChange/index.ts
@@ -1,5 +1,5 @@
 import { noop } from '@modern-kit/utils';
-import { useEventListener } from '../../hooks/useEventListener';
+import { useEventListener } from '../useEventListener';
 import { useCallback } from 'react';
 
 type VisibilityChangeCallbackAction = (


### PR DESCRIPTION
## Overview

`드래그 앤 드롭 이벤트`를 처리하여 `파일`을 수신할 수 있는 영역을 생성하는 커스텀 훅입니다.

```tsx
const Example = () => {
  const { ref, isDragOver } = useDropZone((files) => {
    console.log('files', files);
    setFileNameList(files.map((file) => file.name));
  });

  return <div ref={ref}>DropZone</div>;
};
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)