### PR TITLE
feat(react): useComputedStyleObserver 신규 훅 추가

### DIFF
--- a/.changeset/old-breads-relate.md
+++ b/.changeset/old-breads-relate.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useComputedStyleObserver 신규 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useComputedStyleObserver.mdx
+++ b/docs/docs/react/hooks/useComputedStyleObserver.mdx
@@ -1,0 +1,78 @@
+import { useComputedStyleObserver } from '@modern-kit/react';
+import { useState } from 'react';
+
+# useComputedStyleObserver
+
+관찰할 타겟 요소의 특정 `computed style` 값을 `실시간으로 관찰하고 관리`하는 React 훅
+
+- **[MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)** 를 사용하여 요소의 스타일 속성이 변경될 때 콜백을 호출합니다.
+- **[CSSStyleDeclaration: setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty)** 를 사용하여 요소의 스타일 속성을 직접 변경하더라도 이를 실시간으로 반영합니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useComputedStyleObserver/index.ts)
+
+## Interface
+```ts title="typescript"
+interface UseComputedStyleObserverReturnType<T extends HTMLElement> {
+  ref: React.RefObject<T>;
+  value: string;
+  setValue: (value: string) => void;
+}
+```
+```ts title="typescript"
+function useComputedStyleObserver<T extends HTMLElement>(
+  key: string
+): UseComputedStyleObserverReturnType<T>;
+```
+
+## Usage
+```tsx title="typescript"
+import { useComputedStyleObserver } from '@modern-kit/react';
+
+const Example = () => {
+  const { ref, value, setValue } =
+    useComputedStyleObserver<HTMLDivElement>('color');
+
+  return (
+    <>
+      <div ref={ref} style={{ width: '100px', height: '100px', backgroundColor: 'skyblue' }} />
+      <div>
+        <p>현재 너비: {`${value}`}</p>
+        <button onClick={() => setValue('100px')}>너비 100px로 변경(setValue)</button>
+        <button onClick={() => setValue('300px')}>너비 300px로 변경(setValue)</button>
+
+        <br />
+
+        <button onClick={() => ref.current?.style.setProperty('width', '100px')}>너비 100px로 변경(setProperty)</button>
+        <button onClick={() => ref.current?.style.setProperty('width', '300px')}>너비 300px로 변경(setProperty)</button>
+      </div>
+    </>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const { ref, value, setValue } = useComputedStyleObserver('width');
+
+  return (
+    <>
+      <div ref={ref} style={{ width: '100px', height: '100px', backgroundColor: 'skyblue' }} />
+      <div>
+        <p>현재 너비: {`${value}`}</p>
+        <button onClick={() => setValue('100px')}>너비 100px로 변경(setValue)</button>
+        <button onClick={() => setValue('300px')}>너비 300px로 변경(setValue)</button>
+
+        <br />
+
+        <button onClick={() => ref.current?.style.setProperty('width', '100px')}>너비 100px로 변경(setProperty)</button>
+        <button onClick={() => ref.current?.style.setProperty('width', '300px')}>너비 300px로 변경(setProperty)</button>
+      </div>
+    </>
+  );
+};
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -5,6 +5,7 @@ export * from './useBeforeUnload';
 export * from './useBlockMultipleAsyncCalls';
 export * from './useClipboard';
 export * from './useColorScheme';
+export * from './useComputedStyleObserver';
 export * from './useCounter';
 export * from './useCycleList';
 export * from './useDebounce';

--- a/packages/react/src/hooks/useComputedStyleObserver/index.ts
+++ b/packages/react/src/hooks/useComputedStyleObserver/index.ts
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UseComputedStyleObserverReturnType<T extends HTMLElement> {
+  ref: React.RefObject<T>;
+  value: string;
+  setValue: (value: string) => void;
+}
+
+/**
+ * @description 관찰할 타겟 요소의 특정 computed style 값을 실시간으로 관찰하고 관리하는 React 훅
+ *
+ * MutationObserver를 사용하여 요소의 스타일 속성이 변경될 때 콜백을 호출합니다.
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe
+ *
+ * @template T - 관찰할 HTML 요소 타입, 기본적으로 `HTMLElement`를 상속합니다.
+ * @param {string} key - 관찰할 스타일 속성 키
+ * @returns {UseComputedStyleObserverReturnType<T>} 다음을 포함하는 객체:
+ * - `ref`: 관찰할 타겟 요소에 전달할 ref
+ * - `value`: 현재 계산된 스타일 속성 값
+ * - `setValue`: 관찰중인 스타일 속성 Key에 해당하는 속성 값을 업데이트하는 함수
+ *
+ * @example
+ * ```tsx
+ * const Example = () => {
+ *   const { ref, value, setValue } = useComputedStyleObserver<HTMLDivElement>('color');
+ *
+ *   return (
+ *     <div ref={ref} style={{ color: "black" }}>
+ *       현재 글자 색상: {value}
+ *       <button onClick={() => setValue('red')}>빨간색으로 변경</button>
+ *     </div>
+ *   );
+ * };
+ * ```
+ */
+export function useComputedStyleObserver<T extends HTMLElement>(
+  key: string
+): UseComputedStyleObserverReturnType<T> {
+  const ref = useRef<T>(null);
+  const observerRef = useRef<MutationObserver | null>(null);
+  const [value, setValue] = useState('');
+
+  const setStyleValue = useCallback(
+    (value: string) => {
+      if (!ref.current) return;
+      const targetElement = ref.current;
+
+      targetElement.style.setProperty(key, value);
+      setValue(value);
+    },
+    [key]
+  );
+
+  const updateStyleValue = useCallback(() => {
+    if (!ref.current) return;
+    const targetElement = ref.current;
+
+    const computedStyle = window.getComputedStyle(targetElement);
+    const value = computedStyle.getPropertyValue(key).trim();
+
+    setValue(value);
+  }, [key]);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    const element = ref.current;
+
+    updateStyleValue();
+    observerRef.current = new MutationObserver(updateStyleValue);
+
+    observerRef.current.observe(element, {
+      attributeFilter: ['style', 'class'], // style, class 속성 변경을 관찰
+    });
+
+    return () => {
+      observerRef.current?.disconnect();
+    };
+  }, [updateStyleValue]);
+
+  return { ref, value, setValue: setStyleValue };
+}

--- a/packages/react/src/hooks/useComputedStyleObserver/useComputedStyleObserver.spec.tsx
+++ b/packages/react/src/hooks/useComputedStyleObserver/useComputedStyleObserver.spec.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { useComputedStyleObserver } from '.';
+import { renderSetup } from '../../_internal/test/renderSetup';
+
+const TestComponent = () => {
+  const { ref, value, setValue } =
+    useComputedStyleObserver<HTMLDivElement>('width');
+
+  return (
+    <div ref={ref} style={{ width: '100px' }}>
+      <p role="paragraph">{`${value}`}</p>
+      <button onClick={() => setValue('200px')}>setValue 변경</button>
+      <button onClick={() => ref.current?.style.setProperty('width', '200px')}>
+        setProperty 변경
+      </button>
+    </div>
+  );
+};
+
+describe('useComputedStyleObserver', () => {
+  it('value는 초기 상태가 100px이어야 합니다.', () => {
+    renderSetup(<TestComponent />);
+
+    expect(screen.getByRole('paragraph')).toHaveTextContent('100px');
+  });
+
+  it('setValue 함수를 호출하면 이를 실시간으로 반영해야 합니다.', async () => {
+    const { user } = renderSetup(<TestComponent />);
+
+    await user.click(screen.getByRole('button', { name: 'setValue 변경' }));
+
+    expect(screen.getByRole('paragraph')).toHaveTextContent('200px');
+  });
+
+  it('setProperty로 직접 스타일을 변경하더라도 이를 실시간으로 반영해야 합니다.', async () => {
+    const { user } = renderSetup(<TestComponent />);
+
+    await user.click(screen.getByRole('button', { name: 'setProperty 변경' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('paragraph')).toHaveTextContent('200px');
+    });
+  });
+});


### PR DESCRIPTION
## Overview

관찰할 타겟 요소의 특정 `computed style` 값을 `실시간으로 관찰하고 관리`하는 React 훅

- **[MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe)** 를 사용하여 요소의 스타일 속성이 변경될 때 콜백을 호출합니다.
- **[CSSStyleDeclaration: setProperty](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration/setProperty)** 를 사용하여 요소의 스타일 속성을 직접 변경하더라도 이를 실시간으로 반영합니다.

```tsx
const Example = () => {
  const { ref, value, setValue } = useComputedStyleObserver('width');

  return (
    <>
      <div ref={ref} style={{ width: '100px', height: '100px', backgroundColor: 'skyblue' }} />
      <div>
        <p>현재 너비: {`${value}`}</p>
        <button onClick={() => setValue('100px')}>너비 100px로 변경(setValue)</button>
        <button onClick={() => setValue('300px')}>너비 300px로 변경(setValue)</button>

        <br />

        <button onClick={() => ref.current?.style.setProperty('width', '100px')}>너비 100px로 변경(setProperty)</button>
        <button onClick={() => ref.current?.style.setProperty('width', '300px')}>너비 300px로 변경(setProperty)</button>
      </div>
    </>
  );
};
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)