### PR TITLE
feat(react): mergeEventHandlers 함수 추가

### DIFF
--- a/.changeset/many-actors-taste.md
+++ b/.changeset/many-actors-taste.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): mergeEventHandlers 추가 - @ssi02014

--- a/packages/react/src/utils/mergeEventHandlers/index.ts
+++ b/packages/react/src/utils/mergeEventHandlers/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @description 여러 이벤트 핸들러를 하나의 핸들러로 병합합니다.
+ *
+ * 이벤트 핸들러가 반환하는 값이 `false`일 경우 이후 전달된 이벤트 핸들러의 실행을 중단합니다.
+ *
+ * @param {((event: E) => boolean | void)[]} handlers 병합할 이벤트 핸들러 배열
+ * @returns {((event: E) => void)} 병합된 이벤트 핸들러
+ *
+ * @example
+ * const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+ *   console.log('clicked');
+ * };
+ * const handleClick2 = (event: React.MouseEvent<HTMLButtonElement>) => {
+ *   console.log('clicked2');
+ * };
+ *
+ * const mergedEventHandler = mergeEventHandlers(handleClick, handleClick2);
+ *
+ * @example
+ * // 이벤트 핸들러가 반환하는 값이 `false`일 경우 이후 전달된 이벤트 핸들러의 실행을 중단합니다.
+ * const handleClick1 = (event: React.MouseEvent<HTMLButtonElement>) => {
+ *   console.log('clicked');
+ *
+ *   // 짝수일 경우 false를 반환하여 이후 전달된 이벤트 핸들러의 실행을 중단합니다.
+ *   if (num % 2 === 0) {
+ *     return false;
+ *   }
+ * };
+ *
+ * const handleClick2 = (event: React.MouseEvent<HTMLButtonElement>) => {
+ *   console.log('clicked2');
+ * };
+ *
+ * const mergedEventHandler = mergeEventHandlers(handleClick1, handleClick2);
+ */
+export const mergeEventHandlers = <E>(
+  ...handlers: ((event: E) => boolean | void)[]
+): ((event: E) => void) => {
+  return (event: E) => {
+    for (let i = 0; i < handlers.length; i++) {
+      const result = handlers[i](event);
+
+      if (result === false) {
+        break;
+      }
+    }
+  };
+};

--- a/packages/react/src/utils/mergeEventHandlers/mergeEventHandlers.spec.ts
+++ b/packages/react/src/utils/mergeEventHandlers/mergeEventHandlers.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mergeEventHandlers } from './index';
+
+describe('mergeEventHandlers', () => {
+  it('모든 핸들러가 순서대로 호출되어야 한다', () => {
+    // Arrange
+    const order: number[] = [];
+    const handler1 = vi.fn(() => {
+      order.push(1);
+    });
+    const handler2 = vi.fn(() => {
+      order.push(2);
+    });
+    const handler3 = vi.fn(() => {
+      order.push(3);
+    });
+
+    const event = {} as any;
+    const mergedHandler = mergeEventHandlers(handler1, handler2, handler3);
+
+    mergedHandler(event);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it('핸들러가 false를 반환할 경우 이후 핸들러의 실행을 중단해야 한다', () => {
+    // Arrange
+    const handler1 = vi.fn(() => true);
+    const handler2 = vi.fn(() => false);
+    const handler3 = vi.fn(() => true);
+
+    const event = {} as any;
+    const mergedHandler = mergeEventHandlers(handler1, handler2, handler3);
+
+    // Act
+    mergedHandler(event);
+
+    // Assert
+    expect(handler1).toHaveBeenCalledWith(event);
+    expect(handler2).toHaveBeenCalledWith(event);
+    expect(handler3).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/utils/mergeRefs/index.test.ts
+++ b/packages/react/src/utils/mergeRefs/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mergeRefs } from './index';
+import React from 'react';
+
+describe('mergeRefs', () => {
+  it('함수형 ref를 병합할 수 있어야 한다', () => {
+    const ref1 = vi.fn();
+    const ref2 = vi.fn();
+    const ref3 = vi.fn();
+    const node = { id: 'test-node' };
+
+    const mergedRef = mergeRefs(ref1, ref2, ref3);
+    mergedRef(node);
+
+    expect(ref1).toHaveBeenCalledWith(node);
+    expect(ref2).toHaveBeenCalledWith(node);
+    expect(ref3).toHaveBeenCalledWith(node);
+  });
+
+  it('여러 개의 객체형 ref를 병합할 수 있어야 한다', () => {
+    const ref1: React.MutableRefObject<any> = { current: null };
+    const ref2: React.MutableRefObject<any> = { current: null };
+    const ref3: React.MutableRefObject<any> = { current: null };
+    const node = { id: 'test-node' };
+
+    const mergedRef = mergeRefs(ref1, ref2, ref3);
+    mergedRef(node);
+
+    expect(ref1.current).toBe(node);
+    expect(ref2.current).toBe(node);
+    expect(ref3.current).toBe(node);
+  });
+});

--- a/packages/react/src/utils/mergeRefs/index.ts
+++ b/packages/react/src/utils/mergeRefs/index.ts
@@ -1,6 +1,22 @@
 import { isFunction } from '@modern-kit/utils';
 
-export const mergeRefs = <T = unknown>(...refs: React.Ref<T>[]) => {
+/**
+ * @description 여러 ref 객체를 하나의 ref 객체로 병합합니다.
+ *
+ * @template T - 참조 객체의 타입
+ * @param {React.Ref<T>[]} refs 병합할 참조 객체 배열
+ * @returns {((node: T) => void)} 병합된 참조 객체
+ *
+ * @example
+ * ```tsx
+ * const ref1 = useRef<HTMLDivElement>(null);
+ * const ref2 = useRef<HTMLDivElement>(null);
+ * const mergedRef = mergeRefs(ref1, ref2);
+ * ```
+ */
+export const mergeRefs = <T = unknown>(
+  ...refs: React.Ref<T>[]
+): ((node: T) => void) => {
   return (node: T) =>
     refs.forEach((ref) => {
       if (isFunction(ref)) {


### PR DESCRIPTION
## Overview

여러 이벤트를 병합해주는 mergeEventHandlers 함수 추가

```tsx
const handleClick1 = (e:  React.MouseEvent<HTMLButtonElement>) => { /* ... */ }
const handleClick2 = (e:  React.MouseEvent<HTMLButtonElement>) => { /* ... */ }
const handleClick3 = (e:  React.MouseEvent<HTMLButtonElement>) => { /* ... */ }

const mergedClickEvent = mergeEventHandlers(handleClick1, handleClick2, handleClick3);
```
```tsx
<button onClick={mergedClickEvent} />
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)