### PR TITLE
fix: react/components useMergeRefs 사용으로 변경

### DIFF
--- a/packages/react/src/components/LazyImage/index.tsx
+++ b/packages/react/src/components/LazyImage/index.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react';
 import { useIntersectionObserver } from '../../hooks/useIntersectionObserver';
-import { mergeRefs } from '../../utils/mergeRefs';
+import { useMergeRefs } from '../../hooks/useMergeRefs';
 
 export interface LazyImageProps
   extends React.ComponentProps<'img'>,
@@ -44,7 +44,7 @@ export const LazyImage = forwardRef<HTMLImageElement, LazyImageProps>(
       rootMargin,
     });
 
-    return <img ref={mergeRefs(ref, imgRef)} {...restProps} />;
+    return <img ref={useMergeRefs(ref, imgRef)} {...restProps} />;
   }
 );
 

--- a/packages/react/src/components/OutsidePointerDownHandler/index.tsx
+++ b/packages/react/src/components/OutsidePointerDownHandler/index.tsx
@@ -1,9 +1,9 @@
+import React from 'react';
 import { ReactNode } from 'react';
 import { useOutsidePointerDown } from '../../hooks/useOutsidePointerDown';
-import { mergeRefs } from '../../utils/mergeRefs';
+import { useMergeRefs } from '../../hooks/useMergeRefs';
 import { polymorphicForwardRef } from '../../utils/polymorphicForwardRef';
 import { Slot } from '../Slot';
-import React from 'react';
 
 interface OutsidePointerDownHandlerProps {
   children: ReactNode;
@@ -100,7 +100,7 @@ export const OutsidePointerDownHandler = polymorphicForwardRef<
     }
 
     return (
-      <Wrapper ref={mergeRefs(targetRef, ref)} {...props}>
+      <Wrapper ref={useMergeRefs(targetRef, ref)} {...props}>
         {children}
       </Wrapper>
     );

--- a/packages/react/src/components/Slot/index.tsx
+++ b/packages/react/src/components/Slot/index.tsx
@@ -99,7 +99,7 @@ const SlotClone = React.forwardRef<HTMLElement, SlotCloneProps>(
     const childRef = React.isValidElement(children)
       ? getElementRef(children)
       : null;
-    const mergedRef = useMergeRefs(forwardedRef, childRef);
+    const mergedRefs = useMergeRefs(forwardedRef, childRef);
 
     if (!React.isValidElement(children)) {
       return React.Children.count(children) > 1
@@ -111,7 +111,7 @@ const SlotClone = React.forwardRef<HTMLElement, SlotCloneProps>(
       ...mergeProps(slotProps, children.props as Record<string, any>),
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      ref: forwardedRef ? mergedRef : childRef,
+      ref: forwardedRef ? mergedRefs : childRef,
     });
   }
 );

--- a/packages/react/src/utils/index.ts
+++ b/packages/react/src/utils/index.ts
@@ -1,2 +1,3 @@
+export * from './mergeEventHandlers';
 export * from './mergeRefs';
 export * from './polymorphicForwardRef';


### PR DESCRIPTION
## Overview

기존 mergeRefs 사용을 useMergeRefs 사용으로 변경
- mergeRefs 참조형 문제 발생

<!-- Write a description of your work.  -->

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)