### PR TITLE
feat(react): useManualTimeout 신규 훅 추가

### DIFF
--- a/.changeset/nine-bags-kiss.md
+++ b/.changeset/nine-bags-kiss.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': minor
+---
+
+feat(react): useManualTimeout 신규 훅 추가 - @ssi02014

--- a/docs/docs/react/hooks/useManualTimeout.mdx
+++ b/docs/docs/react/hooks/useManualTimeout.mdx
@@ -1,0 +1,106 @@
+import { useManualTimeout } from '@modern-kit/react';
+import { useState, useEffect } from 'react';
+
+# useManualTimeout
+
+수동으로 타임아웃을 설정하고, 초기화할 수 있는 훅입니다.
+
+`useTimeout` 훅과 다르게 초기 자동 실행이 없으며, 명시적으로 타임아웃을 설정해야 합니다.
+모든 타임아웃은 해당 훅 언마운트 시 자동으로 초기화됩니다.
+
+`useTimeout`은 hooks rule에 따라 중첩 타임아웃 등 복잡한 타임아웃 설정에 적절하지 않습니다.
+`useManualTimeout`은 병렬/중첩된 타임아웃을 실행하고, 한번에 초기화 해야 될 때 유용합니다.
+
+<br />
+
+## Code
+[🔗 실제 구현 코드 확인](https://github.com/modern-agile-team/modern-kit/blob/main/packages/react/src/hooks/useManualTimeout/index.ts)
+
+## Interface
+```ts title="typescript"
+const useManualTimeout: () => {
+  set: (callback: () => void, delay: number) => number;
+  clearAll: () => void;
+}
+```
+
+## Usage
+```tsx title="typescript"
+import { useManualTimeout } from '@modern-kit/react';
+
+const DELAY_TIME = 1500;
+
+const Example = () => {
+  const [number, setNumber] = useState(0);
+
+  const { set } = useManualTimeout();
+
+  const handleSetTimeout = () => {
+    set(() => {
+      setNumber(number + 1);
+    }, DELAY_TIME);
+  }
+
+  useEffect(() => {
+    set(() => {
+      setNumber((prev) => prev + 1);
+
+      set(() => {
+        setNumber((prev) => prev + 2);
+
+        set(() => {
+          setNumber((prev) => prev + 3);
+        }, DELAY_TIME);
+      }, DELAY_TIME);
+    }, DELAY_TIME);
+  }, [set]);
+
+  return (
+    <div>
+      <p>{number}</p>
+      <div>
+        <button onClick={handleSetTimeout}>set</button>
+      </div>
+    </div>
+  );
+};
+```
+
+## Example
+
+export const Example = () => {
+  const [number, setNumber] = useState(0);
+
+  const { set } = useManualTimeout();
+
+  const handleSetTimeout = () => {
+    set(() => {
+      setNumber(number + 1);
+    }, 1500);
+  }
+  
+  useEffect(() => {
+    set(() => {
+      setNumber((prev) => prev + 1);
+
+      set(() => {
+        setNumber((prev) => prev + 2);
+
+        set(() => {
+          setNumber((prev) => prev + 3);
+        }, 1500);
+      }, 1500);
+    }, 1500);
+  }, [set]);
+
+  return (
+    <div>
+      <p>{number}</p>
+      <div>
+        <button onClick={handleSetTimeout}>set</button>
+      </div>
+    </div>
+  );
+};
+
+<Example />

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -29,6 +29,7 @@ export * from './useIsMounted';
 export * from './useIsomorphicLayoutEffect';
 export * from './useKeyDown';
 export * from './useLocalStorage';
+export * from './useManualTimeout';
 export * from './useMediaQuery';
 export * from './useMergeRefs';
 export * from './useMouse';

--- a/packages/react/src/hooks/useManualTimeout/index.ts
+++ b/packages/react/src/hooks/useManualTimeout/index.ts
@@ -1,0 +1,74 @@
+import { useRef, useEffect, useCallback } from 'react';
+
+/**
+ * @description 수동으로 타임아웃을 설정하고, 초기화할 수 있는 훅입니다.
+ *
+ * `useTimeout` 훅과 다르게 초기 자동 실행이 없으며, 명시적으로 타임아웃을 설정해야 합니다.
+ * 모든 타임아웃은 해당 훅 언마운트 시 자동으로 초기화됩니다.
+ *
+ * `useTimeout`은 hooks rule에 따라 중첩 타임아웃 등 복잡한 타임아웃 설정에 적절하지 않습니다.
+ * `useManualTimeout`은 병렬/중첩된 타임아웃을 실행하고, 한번에 초기화 해야 될 때 유용합니다.
+ *
+ * @returns {{
+ *   set: (callback: () => void, delay: number) => number;
+ *   clearAll: () => void;
+ * }}
+ * - set: 타임아웃을 설정하는 함수
+ * - clearAll: 모든 타임아웃을 초기화하는 함수
+ *
+ * @example
+ * const { set, clearAll } = useManualTimeout();
+ *
+ * useEffect(() => {
+ *   // 병렬 실행
+ *   set(() => console.log('timeout1'), 1000);
+ *   set(() => console.log('timeout2'), 2000);
+ * }, [set]);
+ *
+ * @example
+ * const { set, clearAll } = useManualTimeout();
+ *
+ * useEffect(() => {
+ *   // 중첩 실행
+ *   set(() => {
+ *     console.log('timeout1');
+ *     set(() => {
+ *       console.log('timeout2');
+ *       set(() => {
+ *         console.log('timeout3');
+ *       }, 1000);
+ *     }, 2000);
+ *   }, 3000);
+ * }, [set]);
+ */
+export const useManualTimeout = (): {
+  set: (callback: () => void, delay: number) => number;
+  clearAll: () => void;
+} => {
+  const timeoutIds = useRef<number[]>([]);
+
+  const clearAll = useCallback(() => {
+    for (let i = 0; i < timeoutIds.current.length; i++) {
+      clearTimeout(timeoutIds.current[i]);
+    }
+    timeoutIds.current = [];
+  }, []);
+
+  const set = useCallback((callback: () => void, delay: number) => {
+    const id = window.setTimeout(() => {
+      timeoutIds.current = timeoutIds.current.filter(
+        (timeoutId) => timeoutId !== id
+      );
+      callback();
+    }, delay);
+
+    timeoutIds.current.push(id);
+    return id;
+  }, []);
+
+  useEffect(() => {
+    return clearAll;
+  }, [clearAll]);
+
+  return { set, clearAll };
+};

--- a/packages/react/src/hooks/useManualTimeout/useManualTimeout.spec.tsx
+++ b/packages/react/src/hooks/useManualTimeout/useManualTimeout.spec.tsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useManualTimeout } from '.';
+
+const delayTime = 100;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useManualTimeout', () => {
+  const callback1 = vi.fn();
+  const callback2 = vi.fn();
+  const callback3 = vi.fn();
+
+  it('지정된 delay 시간 후에 콜백 함수를 호출해야 합니다.', () => {
+    const mockFn = vi.fn();
+    const { result } = renderHook(() => useManualTimeout());
+
+    result.current.set(mockFn, delayTime);
+
+    expect(mockFn).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+
+    expect(mockFn).toBeCalled();
+  });
+
+  it('여러 개의 타임아웃을 병렬적으로 실행해야 합니다.', () => {
+    const { result } = renderHook(() => useManualTimeout());
+
+    result.current.set(callback1, delayTime);
+    result.current.set(callback2, delayTime);
+    result.current.set(callback3, delayTime * 2);
+
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+    expect(callback3).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+    expect(callback3).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+    expect(callback3).toBeCalledTimes(1);
+  });
+
+  it('중첩된 타임아웃을 지원해야 합니다.', () => {
+    const { result } = renderHook(() => useManualTimeout());
+
+    result.current.set(() => {
+      callback1();
+      result.current.set(() => {
+        callback2();
+        result.current.set(callback3, delayTime);
+      }, delayTime);
+    }, delayTime);
+
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+    expect(callback3).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).not.toBeCalled();
+    expect(callback3).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+    expect(callback3).not.toBeCalled();
+
+    vi.advanceTimersByTime(delayTime);
+    expect(callback1).toBeCalledTimes(1);
+    expect(callback2).toBeCalledTimes(1);
+    expect(callback3).toBeCalledTimes(1);
+  });
+
+  it('clearAll 함수를 호출하면 모든 타임아웃을 초기화해야 합니다.', () => {
+    const { result } = renderHook(() => useManualTimeout());
+
+    result.current.set(callback1, delayTime);
+    result.current.set(callback2, delayTime * 2);
+    result.current.set(callback3, delayTime * 3);
+
+    result.current.clearAll();
+    vi.advanceTimersByTime(delayTime * 3);
+
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+    expect(callback3).not.toBeCalled();
+  });
+
+  it('언마운트 시 모든 타임아웃을 정리해야 합니다.', () => {
+    const { result, unmount } = renderHook(() => useManualTimeout());
+
+    result.current.set(() => {
+      callback1();
+      result.current.set(() => {
+        callback2();
+        result.current.set(callback3, delayTime);
+      }, delayTime);
+    }, delayTime);
+
+    unmount();
+    vi.advanceTimersByTime(delayTime);
+
+    expect(callback1).not.toBeCalled();
+    expect(callback2).not.toBeCalled();
+    expect(callback3).not.toBeCalled();
+  });
+});


### PR DESCRIPTION
## Overview

수동으로 타임아웃을 설정하고, 초기화할 수 있는 훅입니다.

`useTimeout` 훅과 다르게 초기 자동 실행이 없으며, 명시적으로 타임아웃을 설정해야 합니다.
모든 타임아웃은 해당 훅 언마운트 시 자동으로 초기화됩니다.

`useTimeout`은 hooks rule에 따라 중첩 타임아웃 등 복잡한 타임아웃 설정에 적절하지 않습니다.
`useManualTimeout`은 병렬/중첩된 타임아웃을 실행하고, 한번에 초기화 해야 될 때 유용합니다.

```ts
  const [number, setNumber] = useState(0);
  const { set } = useManualTimeout();

  const handleSetTimeout = () => {
    set(() => {
      setNumber(number + 1);
    }, 1500);
  }

  useEffect(() => {
    set(() => {
      setNumber((prev) => prev + 1);

      set(() => {
        setNumber((prev) => prev + 2);

        set(() => {
          setNumber((prev) => prev + 3);
        }, 1500);
      }, 1500);
    }, 1500);
  }, [set]);
```

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)