### PR TITLE
feat(types): EnumerateNumbers 타입 추가

### DIFF
--- a/.changeset/afraid-melons-wonder.md
+++ b/.changeset/afraid-melons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/types': minor
+---
+
+feat(types): EnumerateNumbers type추가 - @zzzRYT

--- a/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
+++ b/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { EnumerateNumbers } from '.';
+
+describe('EnumerateNumbers', () => {
+  it('0 ~ N-1 까지 수라면 해당 정상적으로 타입을 반환하고, 그 외 숫자라면 never 타입을 반환합니다.', () => {
+    const validEnumerate: EnumerateNumbers<5> = 3;
+    const inValidEnumerate = 6 as unknown as EnumerateNumbers<5>;
+
+    expectTypeOf(validEnumerate).toEqualTypeOf<3>();
+    expectTypeOf(inValidEnumerate).not.toMatchTypeOf<6>();
+  });
+
+  it('number타입이 아니라면 never를 반환합니다.', () => {
+    const stringTypeEnumerate = null as unknown as EnumerateNumbers<'5'>;
+    const booleanTypeEnumerate = null as unknown as EnumerateNumbers<true>;
+    const objectTypeEnumerate = null as unknown as EnumerateNumbers<{ a: 1 }>;
+    const arrayTypeEnumerate = null as unknown as EnumerateNumbers<number[]>;
+    const functionTypeEnumerate = null as unknown as EnumerateNumbers<
+      () => void
+    >;
+    const nullTypeEnumerate = null as unknown as EnumerateNumbers<null>;
+    const undefinedTypeEnumerate =
+      null as unknown as EnumerateNumbers<undefined>;
+
+    expectTypeOf(stringTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(booleanTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(objectTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(arrayTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(functionTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(nullTypeEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(undefinedTypeEnumerate).toEqualTypeOf<never>();
+  });
+});

--- a/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
+++ b/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
@@ -11,23 +11,24 @@ describe('EnumerateNumbers', () => {
   });
 
   it('number타입이 아니라면 never를 반환합니다.', () => {
-    const stringTypeEnumerate = null as unknown as EnumerateNumbers<'5'>;
-    const booleanTypeEnumerate = null as unknown as EnumerateNumbers<true>;
-    const objectTypeEnumerate = null as unknown as EnumerateNumbers<{ a: 1 }>;
-    const arrayTypeEnumerate = null as unknown as EnumerateNumbers<number[]>;
-    const functionTypeEnumerate = null as unknown as EnumerateNumbers<
-      () => void
+    const stringTypeEnumerate = '5' as unknown as EnumerateNumbers<'5'>;
+    const booleanTypeEnumerate = true as unknown as EnumerateNumbers<true>;
+    const objectTypeEnumerate = { a: 1 } as unknown as EnumerateNumbers<{
+      a: 1;
+    }>;
+    const arrayTypeEnumerate = [1, 2, 3] as unknown as EnumerateNumbers<
+      number[]
     >;
-    const nullTypeEnumerate = null as unknown as EnumerateNumbers<null>;
-    const undefinedTypeEnumerate =
-      null as unknown as EnumerateNumbers<undefined>;
 
     expectTypeOf(stringTypeEnumerate).toEqualTypeOf<never>();
     expectTypeOf(booleanTypeEnumerate).toEqualTypeOf<never>();
     expectTypeOf(objectTypeEnumerate).toEqualTypeOf<never>();
     expectTypeOf(arrayTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(functionTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(nullTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(undefinedTypeEnumerate).toEqualTypeOf<never>();
+  });
+
+  it('값이 0인 경우 never타입을 반환합니다.', () => {
+    const onlyZero = 0 as unknown as EnumerateNumbers<0>;
+
+    expectTypeOf(onlyZero).toEqualTypeOf<never>();
   });
 });

--- a/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
+++ b/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
@@ -2,18 +2,24 @@ import { describe, it, expectTypeOf } from 'vitest';
 import { EnumerateNumbers } from '.';
 
 describe('EnumerateNumbers', () => {
-  it('0 ~ N-1 까지 수라면 해당 정상적으로 타입을 반환하고, 그 외 숫자라면 never 타입을 반환합니다.', () => {
-    const validEnumerate: EnumerateNumbers<5> = 3;
-    const inValidEnumerate = 6 as unknown as EnumerateNumbers<5>;
+  it('number타입이라면 0 ~ N-1까지 유니언 타입을 반환하고, number타입이 아니라면 never타입을 반환합니다.', () => {
+    const validEnumerate: EnumerateNumbers<6> = 4;
 
-    expectTypeOf(validEnumerate).toEqualTypeOf<3>();
-    expectTypeOf(inValidEnumerate).not.toMatchTypeOf<6>();
-  });
+    const stringEnumerate: EnumerateNumbers<'6'> =
+      '6' as unknown as EnumerateNumbers<'6'>;
+    const booleanEnumerate: EnumerateNumbers<true> =
+      true as unknown as EnumerateNumbers<true>;
+    const objectEnumerate: EnumerateNumbers<{ value: 6 }> = {
+      value: 6,
+    } as unknown as EnumerateNumbers<{ value: 6 }>;
+    const arrayEnumerate: EnumerateNumbers<number[]> = [
+      1, 2, 3,
+    ] as unknown as EnumerateNumbers<number[]>;
 
-  it('Acc 배열을 사용하여 시작 인덱스를 조정할 수 있습니다.', () => {
-    type TwoToFive = EnumerateNumbers<6, [0, 0]>;
-    const startTwo = 3 as unknown as TwoToFive;
-
-    expectTypeOf(startTwo).toEqualTypeOf<2 | 3 | 4 | 5>();
+    expectTypeOf(validEnumerate).toEqualTypeOf<4>();
+    expectTypeOf(stringEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(booleanEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(objectEnumerate).toEqualTypeOf<never>();
+    expectTypeOf(arrayEnumerate).toEqualTypeOf<never>();
   });
 });

--- a/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
+++ b/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
@@ -2,9 +2,13 @@ import { describe, it, expectTypeOf } from 'vitest';
 import { EnumerateNumbers } from '.';
 
 describe('EnumerateNumbers', () => {
-  it('number타입이라면 0 ~ N-1까지 유니언 타입을 반환하고, number타입이 아니라면 never타입을 반환합니다.', () => {
+  it('number 타입이라면 0 ~ N-1까지의 숫자 유니언 타입을 생성합니다.', () => {
     const validEnumerate: EnumerateNumbers<6> = 4;
 
+    expectTypeOf(validEnumerate).toEqualTypeOf<4>();
+  });
+
+  it('number타입이 아니라면 never타입을 반환합니다.', () => {
     const stringEnumerate: EnumerateNumbers<'6'> =
       '6' as unknown as EnumerateNumbers<'6'>;
     const booleanEnumerate: EnumerateNumbers<true> =
@@ -16,7 +20,6 @@ describe('EnumerateNumbers', () => {
       1, 2, 3,
     ] as unknown as EnumerateNumbers<number[]>;
 
-    expectTypeOf(validEnumerate).toEqualTypeOf<4>();
     expectTypeOf(stringEnumerate).toEqualTypeOf<never>();
     expectTypeOf(booleanEnumerate).toEqualTypeOf<never>();
     expectTypeOf(objectEnumerate).toEqualTypeOf<never>();

--- a/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
+++ b/packages/types/src/EnumerateNumbers/EnumerateNumbers.spec.ts
@@ -10,25 +10,10 @@ describe('EnumerateNumbers', () => {
     expectTypeOf(inValidEnumerate).not.toMatchTypeOf<6>();
   });
 
-  it('number타입이 아니라면 never를 반환합니다.', () => {
-    const stringTypeEnumerate = '5' as unknown as EnumerateNumbers<'5'>;
-    const booleanTypeEnumerate = true as unknown as EnumerateNumbers<true>;
-    const objectTypeEnumerate = { a: 1 } as unknown as EnumerateNumbers<{
-      a: 1;
-    }>;
-    const arrayTypeEnumerate = [1, 2, 3] as unknown as EnumerateNumbers<
-      number[]
-    >;
+  it('Acc 배열을 사용하여 시작 인덱스를 조정할 수 있습니다.', () => {
+    type TwoToFive = EnumerateNumbers<6, [0, 0]>;
+    const startTwo = 3 as unknown as TwoToFive;
 
-    expectTypeOf(stringTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(booleanTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(objectTypeEnumerate).toEqualTypeOf<never>();
-    expectTypeOf(arrayTypeEnumerate).toEqualTypeOf<never>();
-  });
-
-  it('값이 0인 경우 never타입을 반환합니다.', () => {
-    const onlyZero = 0 as unknown as EnumerateNumbers<0>;
-
-    expectTypeOf(onlyZero).toEqualTypeOf<never>();
+    expectTypeOf(startTwo).toEqualTypeOf<2 | 3 | 4 | 5>();
   });
 });

--- a/packages/types/src/EnumerateNumbers/index.ts
+++ b/packages/types/src/EnumerateNumbers/index.ts
@@ -1,11 +1,16 @@
 /**
  * @description 0부터 N-1까지의 숫자 유니언 타입을 생성합니다. N이 number타입이 아닐경우 never를 반환합니다.
  *
- * @template N - 생성할 숫자 범위의 상한값 (5면 0, 1, 2, 3, 4를 생성)
- * @template Acc - 재귀적으로 누적되는 배열 타입, 기본값은 빈 배열입니다.
+ * @template N - 생성할 숫자 범위의 상한값
+ * @template Acc - 재귀적으로 숫자를 누적하는 배열 타입입니다. 배열의 길이를 기반으로 시작 인덱스를 지정할 수 있습니다.
+ * - 예를 들어, [0, 0]이면 길이가 2이므로 2부터 시작하는 유니언 타입이 생성됩니다. 내부 값은 크게 영향을 주지 않습니다.
+ * - 기본값은 빈 배열입니다.
  *
  * @example
  * type zeroToFive = EnumerateNumbers<6>; // 0 | 1 | 2 | 3 | 4 | 5
+ * type twoToFive = EnumerateNumbers<6, [0, 0]>; // 2 | 3 | 4 | 5 (Acc 배열 길이가 2이므로 2부터 시작)
+ *
+ * @example
  * type otherTypeEnumerate = EnumerateNumbers<'6'>; // never
  */
 export type EnumerateNumbers<
@@ -13,6 +18,8 @@ export type EnumerateNumbers<
   Acc extends number[] = []
 > = N extends number
   ? Acc['length'] extends N
-    ? Acc[number]
+    ? Acc extends []
+      ? Acc[number]
+      : Exclude<Acc[number], 0>
     : EnumerateNumbers<N, [...Acc, Acc['length']]>
   : never;

--- a/packages/types/src/EnumerateNumbers/index.ts
+++ b/packages/types/src/EnumerateNumbers/index.ts
@@ -8,7 +8,10 @@
  * type zeroToFive = EnumerateNumbers<6>; // 0 | 1 | 2 | 3 | 4 | 5
  * type otherTypeEnumerate = EnumerateNumbers<'6'>; // never
  */
-export type EnumerateNumbers<N, Acc extends number[] = []> = N extends number
+export type EnumerateNumbers<
+  N extends number,
+  Acc extends number[] = []
+> = N extends number
   ? Acc['length'] extends N
     ? Acc[number]
     : EnumerateNumbers<N, [...Acc, Acc['length']]>

--- a/packages/types/src/EnumerateNumbers/index.ts
+++ b/packages/types/src/EnumerateNumbers/index.ts
@@ -1,25 +1,21 @@
+type _EnumerateNumbers<
+  N extends number,
+  Acc extends number[] = []
+> = Acc['length'] extends N
+  ? Acc[number]
+  : _EnumerateNumbers<N, [...Acc, Acc['length']]>;
+
 /**
  * @description 0부터 N-1까지의 숫자 유니언 타입을 생성합니다. N이 number타입이 아닐경우 never를 반환합니다.
  *
  * @template N - 생성할 숫자 범위의 상한값
- * @template Acc - 재귀적으로 숫자를 누적하는 배열 타입입니다. 배열의 길이를 기반으로 시작 인덱스를 지정할 수 있습니다.
- * - 예를 들어, [0, 0]이면 길이가 2이므로 2부터 시작하는 유니언 타입이 생성됩니다. 내부 값은 크게 영향을 주지 않습니다.
- * - 기본값은 빈 배열입니다.
  *
  * @example
  * type zeroToFive = EnumerateNumbers<6>; // 0 | 1 | 2 | 3 | 4 | 5
- * type twoToFive = EnumerateNumbers<6, [0, 0]>; // 2 | 3 | 4 | 5 (Acc 배열 길이가 2이므로 2부터 시작)
  *
  * @example
  * type otherTypeEnumerate = EnumerateNumbers<'6'>; // never
  */
-export type EnumerateNumbers<
-  N extends number,
-  Acc extends number[] = []
-> = N extends number
-  ? Acc['length'] extends N
-    ? Acc extends []
-      ? Acc[number]
-      : Exclude<Acc[number], 0>
-    : EnumerateNumbers<N, [...Acc, Acc['length']]>
+export type EnumerateNumbers<N> = N extends number
+  ? _EnumerateNumbers<N>
   : never;

--- a/packages/types/src/EnumerateNumbers/index.ts
+++ b/packages/types/src/EnumerateNumbers/index.ts
@@ -1,0 +1,5 @@
+export type EnumerateNumbers<N, Acc extends number[] = []> = N extends number
+  ? Acc['length'] extends N
+    ? Acc[number]
+    : EnumerateNumbers<N, [...Acc, Acc['length']]>
+  : never;

--- a/packages/types/src/EnumerateNumbers/index.ts
+++ b/packages/types/src/EnumerateNumbers/index.ts
@@ -1,3 +1,13 @@
+/**
+ * @description 0부터 N-1까지의 숫자 유니언 타입을 생성합니다. N이 number타입이 아닐경우 never를 반환합니다.
+ *
+ * @template N - 생성할 숫자 범위의 상한값 (5면 0, 1, 2, 3, 4를 생성)
+ * @template Acc - 재귀적으로 누적되는 배열 타입, 기본값은 빈 배열입니다.
+ *
+ * @example
+ * type zeroToFive = EnumerateNumbers<6>; // 0 | 1 | 2 | 3 | 4 | 5
+ * type otherTypeEnumerate = EnumerateNumbers<'6'>; // never
+ */
 export type EnumerateNumbers<N, Acc extends number[] = []> = N extends number
   ? Acc['length'] extends N
     ? Acc[number]

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -2,6 +2,7 @@ export * from './Arrayable';
 export * from './DeepPartial';
 export * from './DeepRequired';
 export * from './DistributiveOmit';
+export * from './EnumerateNumbers';
 export * from './ExcludeNullish';
 export * from './ExtractMapType';
 export * from './ExtractNestedArrayType';


### PR DESCRIPTION
## Overview

Issue: #893 

<!-- Write a description of your work.  -->

0 ~ N-1 번째 까지 숫자 유니언 타입을 생성합니다.
```
type EnumerateNumbers<N, Acc extends number[] = []> = N extends number
  ? Acc['length'] extends N
    ? Acc[number]
    : EnumerateNumbers<N, [...Acc, Acc['length']]>
  : never;
```
number가 아닌 다른 타입을 사용했을 시 never가 반환되도록 수정했습니다.

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)