### PR TITLE
chore: modern-kit/react 내에 lodash 함수들 modern-kit/utils 함수로 대체 및 테스트 코드 개선

### DIFF
--- a/.changeset/social-wombats-notice.md
+++ b/.changeset/social-wombats-notice.md
@@ -1,0 +1,5 @@
+---
+'@modern-kit/react': patch
+---
+
+fix(react): debounce 관련 훅 타입 및 주석 개선 - @ssi02014

--- a/docs/docs/react/hooks/useDebounce.mdx
+++ b/docs/docs/react/hooks/useDebounce.mdx
@@ -3,7 +3,7 @@ import { useDebounce } from '@modern-kit/react'
 
 # useDebounce
 
-`debounce`를 쉽게 사용할 수 있는 커스텀 훅입니다.
+주어진 콜백 함수를 `디바운스(지연)` 처리하여 특정 시간 동안 반복 호출을 방지하는 훅입니다.
 
 <br />
 
@@ -12,24 +12,33 @@ import { useDebounce } from '@modern-kit/react'
 
 ## Interface
 ```ts title="typescript"
-interface DebounceSettings {
-  signal?: AbortSignal;
-  leading?: boolean;
-  maxWait?: number;
-  trailing?: boolean;
-}
-
+/**
+ * @interface DebounceParameters
+ * @template T - 콜백 함수 타입입니다.
+ * @param {DebounceParameters[0]} callback - 디바운스할 콜백 함수입니다.
+ * @param {DebounceParameters[1]} wait - 지연시킬 시간(밀리초)입니다.
+ * @param {DebounceParameters[2]} options - 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 디바운스된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {number} options.maxWait - 최대 대기 시간(밀리초)입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
+ */
 type DebounceParameters = Parameters<typeof debounce>;
 
-type DebounceReturnType<T extends DebounceParameters[0]> = ReturnType<
+/**
+ * @interface DebounceReturnType
+ * @param {() => void} cancel - 디바운스된 함수의 대기 중인 실행을 취소합니다.
+ * @param {() => void} flush - 대기 중인 실행이 있는 경우 디바운스된 함수를 즉시 실행합니다.
+ */
+type DebounceReturnType<T extends (...args: any) => any> = ReturnType<
   typeof debounce<T>
 >;
 ```
 ```ts title="typescript"
 function useDebounce<T extends (...args: any) => any>(
   callback: T,
-  wait: DebounceParameters[1], // number
-  options?: DebounceParameters[2] // DebounceSettings
+  wait: DebounceParameters[1],
+  options?: DebounceParameters[2]
 ): DebounceReturnType<T>;
 ```
 

--- a/docs/docs/react/hooks/useDebouncedInputValue.mdx
+++ b/docs/docs/react/hooks/useDebouncedInputValue.mdx
@@ -14,7 +14,18 @@ import { useDebouncedInputValue } from '@modern-kit/react'
 
 ## Interface
 ```ts title="typescript"
-type DebounceParameters = Parameters<typeof debounce>;
+/**
+ * @interface DebounceParameters
+ * @template T - 콜백 함수 타입입니다.
+ * @param {DebounceParameters[0]} callback - 디바운스할 콜백 함수입니다.
+ * @param {DebounceParameters[1]} wait - 지연시킬 시간(밀리초)입니다.
+ * @param {DebounceParameters[2]} options - 디바운스 동작과 관련된 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 디바운스된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {number} options.maxWait - 최대 대기 시간(밀리초)입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
+ */
+type DebounceParameters = Parameters<typeof useDebounce>;
 ```
 ```ts title="typescript"
 function useDebouncedInputValue(

--- a/docs/docs/react/hooks/useDebouncedState.mdx
+++ b/docs/docs/react/hooks/useDebouncedState.mdx
@@ -12,9 +12,26 @@ import { useDebouncedState } from '@modern-kit/react'
 
 ## Interface
 ```ts title="typescript"
-type DebounceParameters = Parameters<typeof debounce>;
-type DebounceReturnType<T extends DebounceParameters[0]> = ReturnType<
-  typeof debounce<T>
+/**
+ * @interface DebounceParameters
+ * @template T - 콜백 함수 타입입니다.
+ * @param {DebounceParameters[0]} callback - 디바운스할 콜백 함수입니다.
+ * @param {DebounceParameters[1]} wait - 지연시킬 시간(밀리초)입니다.
+ * @param {DebounceParameters[2]} options - 디바운스 동작과 관련된 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 디바운스된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {number} options.maxWait - 최대 대기 시간(밀리초)입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
+ */
+type DebounceParameters = Parameters<typeof useDebounce>;
+
+/**
+ * @interface DebounceReturnType
+ * @param {() => void} cancel - 디바운스된 함수의 대기 중인 실행을 취소합니다.
+ * @param {() => void} flush - 대기 중인 실행이 있는 경우 디바운스된 함수를 즉시 실행합니다.
+ */
+type DebounceReturnType<T extends (...args: any) => any> = ReturnType<
+  typeof useDebounce<T>
 >;
 ```
 ```ts title="typescript"

--- a/docs/docs/react/hooks/useThrottle.mdx
+++ b/docs/docs/react/hooks/useThrottle.mdx
@@ -3,7 +3,7 @@ import { useThrottle } from '@modern-kit/react'
 
 # useThrottle
 
-`throttle`을 쉽게 사용할 수 있는 커스텀 훅입니다.
+주어진 콜백 함수를 지정된 시간 동안 `쓰로틀링` 처리하여 특정 시간 동안 반복 호출을 방지하는 훅입니다.
 
 <br />
 
@@ -12,16 +12,30 @@ import { useThrottle } from '@modern-kit/react'
 
 ## Interface
 ```ts title="typescript"
-interface ThrottleSettings {
-  signal?: AbortSignal;
-  leading?: boolean;
-  trailing?: boolean;
-}
-
+/**
+ * @interface ThrottleParameters
+ * @template T - 콜백 함수 타입입니다.  
+ * @param {ThrottleParameters[0]} callback - 스로틀링할 콜백 함수입니다.
+ * @param {ThrottleParameters[1]} wait - 스로틀링 시간(밀리초)입니다.
+ * @param {ThrottleParameters[2]} options - 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 스로틀링된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
+ */
 type ThrottleParameters = Parameters<typeof throttle>;
+
+/**
+ * @interface ThrottleReturnType
+ * @template T - 콜백 함수 타입입니다.
+ * @param {() => void} cancel - 스로틀링된 함수의 대기 중인 실행을 취소합니다.
+ * @param {() => void} flush - 대기 중인 실행이 있는 경우 스로틀링된 함수를 즉시 실행합니다.
+ */
+type ThrottleReturnType<T extends (...args: any) => any> = ReturnType<
+  typeof throttle<T>
+>;
 ```
 ```ts title="typescript"
-function useThrottle<T extends ThrottleParameters[0]>(
+function useThrottle<T extends (...args: any) => any>(
   callback: T,
   wait: ThrottleParameters[1],
   options?: ThrottleParameters[2]

--- a/packages/react/src/components/DebounceHandler/index.tsx
+++ b/packages/react/src/components/DebounceHandler/index.tsx
@@ -1,12 +1,12 @@
 import { Children, cloneElement } from 'react';
-import { DebounceParameters, useDebounce } from '../../hooks/useDebounce';
+import { useDebounce } from '../../hooks/useDebounce';
 import { isFunction } from '@modern-kit/utils';
 
 interface DebounceHandlerProps {
   children: JSX.Element;
   capture: string;
-  wait: DebounceParameters[1];
-  options?: DebounceParameters[2];
+  wait: Parameters<typeof useDebounce>[1];
+  options?: Parameters<typeof useDebounce>[2];
 }
 
 /**

--- a/packages/react/src/hooks/useDebounce/useDebounce.spec.tsx
+++ b/packages/react/src/hooks/useDebounce/useDebounce.spec.tsx
@@ -14,21 +14,7 @@ afterEach(() => {
 const DELAY_TIME = 200;
 
 describe('useDebounce', () => {
-  it('주어진 시간이 지난 후에 전달된 함수가 호출되어야 합니다', () => {
-    const mockFn = vi.fn();
-
-    const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
-
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(0);
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(1);
-  });
-
-  it('지연 시간 내에 여러 번 호출되어도 한 번만 실행되어야 합니다', () => {
+  it('함수 호출을 디바운스해야 한다', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
@@ -37,50 +23,73 @@ describe('useDebounce', () => {
     result.current();
     result.current();
 
-    expect(mockFn).toBeCalledTimes(0);
-
     vi.advanceTimersByTime(DELAY_TIME);
     expect(mockFn).toBeCalledTimes(1);
-
-    result.current();
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME);
-    expect(mockFn).toBeCalledTimes(2);
-
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME);
-    expect(mockFn).toBeCalledTimes(3);
   });
 
-  it('지연 시간 내에 함수가 다시 호출되면, 마지막 호출을 기준으로 지연 시간이 재설정되어야 합니다.', () => {
+  it('지정된 대기 시간만큼 함수 호출을 지연시켜야 한다', async () => {
     const mockFn = vi.fn();
+
     const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
 
     result.current();
-    expect(mockFn).toBeCalledTimes(0);
+    vi.advanceTimersByTime(DELAY_TIME / 2);
+    expect(mockFn).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(0);
-
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(0);
-
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(0);
-
-    result.current();
-
-    vi.advanceTimersByTime(DELAY_TIME);
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it('컴포넌트가 언마운트되면 디바운스가 취소되어야 합니다', () => {
+  it('대기 시간이 끝나기 전에 다시 호출되면 대기 시간을 리셋해야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 2);
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 2);
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 2);
+
+    result.current();
+
+    expect(mockFn).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('디바운스된 함수 호출을 취소할 수 있어야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
+
+    result.current();
+
+    result.current.cancel(); // 디바운스 함수 호출 취소
+
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    expect(mockFn).not.toHaveBeenCalled();
+  });
+
+  it('함수를 올바른 인자와 함께 호출해야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() => useDebounce(mockFn, DELAY_TIME));
+
+    result.current('test', 123);
+
+    vi.advanceTimersByTime(DELAY_TIME * 2);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledWith('test', 123);
+  });
+
+  it('언마운트 시 디바운스가 취소되야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { result, unmount } = renderHook(() =>
@@ -89,40 +98,127 @@ describe('useDebounce', () => {
 
     result.current();
 
-    expect(mockFn).toBeCalledTimes(0);
+    unmount(); // 언마운트
 
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-
-    unmount();
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(0);
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).not.toHaveBeenCalled();
   });
 
-  it('leading 옵션이 true로 설정된 경우 초기 호출을 실행해야 합니다', () => {
+  it('maxWait 옵션을 사용해 최대 대기 시간을 설정할 수 있어야 한다', async () => {
     const mockFn = vi.fn();
+
     const { result } = renderHook(() =>
-      useDebounce(mockFn, DELAY_TIME, { leading: true })
+      useDebounce(mockFn, DELAY_TIME, {
+        maxWait: DELAY_TIME / 2, // 25ms
+      })
     );
 
-    result.current(); // 즉시 호출
-    expect(mockFn).toBeCalledTimes(1);
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 5); // 10ms
+    expect(mockFn).toHaveBeenCalledTimes(0);
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 5); // 10ms
+    expect(mockFn).toHaveBeenCalledTimes(0);
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME / 10); //5ms
+
+    // debounce는 기본적으로 호출되면 대기 시간이 초기화됩니다.
+    // maxWait 옵션은 연속적인 호출이 발생하더라도 첫 호출 기준으로 최대 대기 시간이 지나면 강제로 함수가 실행됩니다.
+    expect(mockFn).toHaveBeenCalledTimes(1);
   });
 
-  it('AbortController을 통해 초기 호출을 중단할 수 있어야 한다', () => {
+  it('leading: true, trailing: true 일 때 처음 호출과 마지막 호출을 모두 실행해야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDebounce(mockFn, DELAY_TIME, {
+        leading: true,
+        trailing: true,
+      })
+    );
+
+    result.current();
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    result.current(); // 대기 시간 내 호출, trailing: true 이므로 후행 호출
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    expect(mockFn).toHaveBeenCalledTimes(2);
+  });
+
+  it('leading: true, trailing: false 일 때 처음 호출을 실행하고 마지막 호출을 실행하지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDebounce(mockFn, DELAY_TIME, {
+        leading: true,
+        trailing: false,
+      })
+    );
+
+    result.current();
+    expect(mockFn).toHaveBeenCalledTimes(1);
+
+    result.current(); // 대기 시간 내 호출, trailing: false 이므로 후행 호출되지 않음
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('leading: false, trailing: true 일 때 처음 호출을 실행하지 않고 마지막 호출을 실행해야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDebounce(mockFn, DELAY_TIME, {
+        leading: false,
+        trailing: true,
+      })
+    );
+
+    result.current(); // leading: false 이므로 대기 시간 이후 후행 호출
+    expect(mockFn).toHaveBeenCalledTimes(0);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('leading: false, trailing: false 일 때 처음 호출과 마지막 호출을 모두 실행하지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useDebounce(mockFn, DELAY_TIME, {
+        leading: false,
+        trailing: false,
+      })
+    );
+
+    result.current();
+    expect(mockFn).toHaveBeenCalledTimes(0);
+
+    result.current();
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    expect(mockFn).toHaveBeenCalledTimes(0);
+  });
+
+  it('AbortSignal에 의해 중단된 경우 디바운스된 함수를 호출하지 않아야 한다', async () => {
     const mockFn = vi.fn();
     const controller = new AbortController();
+    const signal = controller.signal;
 
     controller.abort();
 
     const { result } = renderHook(() =>
-      useDebounce(mockFn, DELAY_TIME, { signal: controller.signal })
+      useDebounce(mockFn, DELAY_TIME, { signal })
     );
 
     result.current();
-    expect(mockFn).toBeCalledTimes(0);
 
     vi.advanceTimersByTime(DELAY_TIME);
-    expect(mockFn).toBeCalledTimes(0);
+
+    expect(mockFn).not.toHaveBeenCalled();
   });
 });

--- a/packages/react/src/hooks/useDebouncedInputValue/index.ts
+++ b/packages/react/src/hooks/useDebouncedInputValue/index.ts
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
-import { type DebounceParameters } from '../../hooks/useDebounce';
-import { useDebouncedState } from '../../hooks/useDebouncedState';
+import { useDebouncedState } from '../useDebouncedState';
+import { useDebounce } from '../useDebounce';
+
+type DebounceParameters = Parameters<typeof useDebounce>;
 
 interface UseDebouncedInputValueReturnType {
   value: string;
@@ -16,8 +18,12 @@ interface UseDebouncedInputValueReturnType {
  * 현재 입력 값과 디바운싱된 값을 제공하며, 값을 업데이트하고 리셋할 수 있는 함수도 함께 제공합니다.
  *
  * @param {string} initialValue - 초기 입력 값입니다.
- * @param {DebounceParameters[1]} [wait] - 입력 값에 디바운싱을 적용할 때의 지연 시간(밀리초)입니다.
- * @param {DebounceParameters[2]} [options={}] - 디바운스 동작에 대한 선택적 구성 옵션입니다.
+ * @param {DebounceParameters[1]} wait - 입력 값에 디바운싱을 적용할 때의 지연 시간(밀리초)입니다.
+ * @param {DebounceParameters[2]} options - 디바운스 동작과 관련된 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 디바운스된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {number} options.maxWait - 최대 대기 시간(밀리초)입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
  *
  * @returns {UseDebouncedInputValueReturnType}
  * - `value`: 현재 입력 값

--- a/packages/react/src/hooks/useDebouncedState/index.ts
+++ b/packages/react/src/hooks/useDebouncedState/index.ts
@@ -1,17 +1,22 @@
-import {
-  DebounceParameters,
-  DebounceReturnType,
-  useDebounce,
-} from '../../hooks/useDebounce';
+import { useDebounce } from '../useDebounce';
 import { useState, Dispatch } from 'react';
+
+type DebounceParameters = Parameters<typeof useDebounce>;
+type DebounceReturnType<T extends (...args: any) => any> = ReturnType<
+  typeof useDebounce<T>
+>;
 
 /**
  * @description useState의 디바운스 버전의 훅입니다.
  *
  * @template T - 상태의 타입을 나타냅니다.
  * @param {T} initialState - 초기 상태 값입니다.
- * @param {DebounceParameters[1]} [wait] - 상태 업데이트 전에 기다리는 지연 시간(밀리초)입니다.
- * @param {DebounceParameters[2]} [options={}] - 디바운스 동작에 영향을 주는 추가 옵션입니다. `leading(default: false)`, `trailing(default: true)`, `maxWait` 옵션을 받을 수 있습니다.
+ * @param {DebounceParameters[1]} wait - 상태 업데이트 전에 기다리는 지연 시간(밀리초)입니다.
+ * @param {DebounceParameters[2]} options - 디바운스 동작과 관련된 옵션 객체입니다.
+ * @param {AbortSignal} options.signal - 디바운스된 함수를 취소하기 위한 선택적 AbortSignal입니다.
+ * @param {number} options.maxWait - 최대 대기 시간(밀리초)입니다.
+ * @param {boolean} options.leading - 첫 번째 호출을 실행할지 여부입니다.
+ * @param {boolean} options.trailing - 마지막 호출을 실행할지 여부입니다.
  * @returns {[T, DebounceReturnType<Dispatch<React.SetStateAction<T>>>]} - 현재 디바운스된 상태와 상태를 업데이트하는 함수를 포함하는 배열을 반환합니다.
  *
  * @example

--- a/packages/react/src/hooks/useDebouncedState/useDebouncedState.spec.tsx
+++ b/packages/react/src/hooks/useDebouncedState/useDebouncedState.spec.tsx
@@ -4,7 +4,7 @@ import { renderSetup } from '../../_internal/test/renderSetup';
 import { useDebouncedState } from '.';
 import { delay } from '@modern-kit/utils';
 
-const DELAY_TIME = 300;
+const DELAY_TIME = 50;
 
 const TestComponent = () => {
   const [debouncedState, setDebouncedState] = useDebouncedState('', DELAY_TIME);
@@ -25,10 +25,10 @@ describe('useDebouncedState', () => {
 
     await user.type(input, 'test');
 
-    await delay(100);
+    await delay(DELAY_TIME / 2);
     expect(debouncedState).toHaveTextContent('');
 
-    await delay(200);
+    await delay(DELAY_TIME / 2);
     expect(debouncedState).toHaveTextContent('test');
   });
 
@@ -42,10 +42,10 @@ describe('useDebouncedState', () => {
     await user.type(input, '1234');
     await user.type(input, 'bgzt');
 
-    await delay(100);
+    await delay(DELAY_TIME / 2);
     expect(debouncedState).toHaveTextContent('');
 
-    await delay(200);
+    await delay(DELAY_TIME / 2);
     expect(debouncedState).toHaveTextContent('bgzt');
   });
 });

--- a/packages/react/src/hooks/useThrottle/index.ts
+++ b/packages/react/src/hooks/useThrottle/index.ts
@@ -3,8 +3,8 @@ import { throttle } from '@modern-kit/utils';
 import { useUnmount } from '../useUnmount';
 import { usePreservedCallback } from '../usePreservedCallback';
 
-export type ThrottleParameters = Parameters<typeof throttle>;
-export type ThrottleReturnType<T extends ThrottleParameters[0]> = ReturnType<
+type ThrottleParameters = Parameters<typeof throttle>;
+type ThrottleReturnType<T extends (...args: any) => any> = ReturnType<
   typeof throttle<T>
 >;
 

--- a/packages/react/src/hooks/useThrottle/useThrottle.spec.ts
+++ b/packages/react/src/hooks/useThrottle/useThrottle.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useThrottle } from '.';
 
-const DELAY_TIME = 300;
+const DELAY_TIME = 50;
 
 beforeEach(() => {
   // https://github.com/testing-library/user-event/issues/833#issuecomment-1725364780
@@ -14,25 +14,7 @@ afterEach(() => {
 });
 
 describe('useThrottle', () => {
-  it('타임아웃 이전에 콜백 함수가 호출되어야 합니다.', () => {
-    const mockFn = vi.fn();
-
-    const { result } = renderHook(() => useThrottle(mockFn, DELAY_TIME));
-
-    result.current();
-
-    expect(mockFn).toBeCalledTimes(1);
-
-    vi.advanceTimersByTime(100);
-
-    expect(mockFn).toBeCalledTimes(1);
-
-    vi.advanceTimersByTime(200);
-
-    expect(mockFn).toBeCalledTimes(1);
-  });
-
-  it('대기 시간 내에 호출되지 않으면 함수가 즉시 실행되어야 합니다.', () => {
+  it('함수 호출을 스로틀링해야 한다', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(() => useThrottle(mockFn, DELAY_TIME));
@@ -40,32 +22,38 @@ describe('useThrottle', () => {
     result.current(); // 첫 호출은 즉시 실행
     expect(mockFn).toBeCalledTimes(1);
 
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toBeCalledTimes(1);
-
     result.current(); // 대기 시간 내에 호출되기 때문에 무시
-    expect(mockFn).toBeCalledTimes(1);
+    result.current();
 
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(DELAY_TIME);
 
-    result.current(); // 대기 시간 이후에 호출되기 때문에 실행
-    expect(mockFn).toBeCalledTimes(2);
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toHaveBeenCalledTimes(2);
-
-    result.current(); // 대기 시간 내에 호출되기 때문에 무시
-    expect(mockFn).toHaveBeenCalledTimes(2);
-
-    vi.advanceTimersByTime(DELAY_TIME / 2);
-    expect(mockFn).toHaveBeenCalledTimes(2);
-
-    result.current(); // 대기 시간 이후에 호출되기 때문에 실행
-    expect(mockFn).toHaveBeenCalledTimes(3);
+    expect(mockFn).toBeCalledTimes(2); // 대기 시간 이후 실행
   });
 
-  it('컴포넌트가 언마운트되면 쓰로틀링이 취소되어야 합니다.', () => {
+  it('함수가 올바른 인자와 함께 호출되어야 한다', () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() => useThrottle(mockFn, DELAY_TIME));
+
+    result.current('test', 123);
+
+    expect(mockFn).toHaveBeenCalledTimes(1);
+    expect(mockFn).toHaveBeenCalledWith('test', 123);
+  });
+
+  it('한 번만 호출될 때는 후행 호출이 트리거되지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() => useThrottle(mockFn, DELAY_TIME));
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(1);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('언마운트 시 쓰로틀링이 취소되야 합니다.', () => {
     const mockFn = vi.fn();
 
     const { result, unmount } = renderHook(() =>
@@ -73,26 +61,19 @@ describe('useThrottle', () => {
     );
 
     result.current();
-
     expect(mockFn).toBeCalledTimes(1);
-
-    vi.advanceTimersByTime(100);
 
     result.current();
     result.current();
 
-    vi.advanceTimersByTime(100);
+    unmount(); // 언마운트
 
-    unmount();
+    vi.advanceTimersByTime(DELAY_TIME);
 
-    expect(mockFn).toBeCalledTimes(1);
-
-    vi.advanceTimersByTime(100);
-
-    expect(mockFn).toBeCalledTimes(1);
+    expect(mockFn).toBeCalledTimes(1); // 언마운트 되어 쓰로틀링이 취소되어 실행되지 않음
   });
 
-  it('trailing 옵션이 false로 설정된 경우 마지막에 함수가 호출되지 않아야 합니다.', () => {
+  it('trailing 옵션이 false인 경우 마지막 호출을 무시해야 한다', () => {
     const mockFn = vi.fn();
 
     const { result } = renderHook(() =>
@@ -100,23 +81,97 @@ describe('useThrottle', () => {
     );
 
     result.current();
-
     expect(mockFn).toBeCalledTimes(1);
 
-    vi.advanceTimersByTime(100);
-
-    result.current();
     result.current();
 
-    vi.advanceTimersByTime(200);
-
+    vi.advanceTimersByTime(DELAY_TIME);
     expect(mockFn).toBeCalledTimes(1);
   });
 
-  it('AbortController을 통해 초기 호출을 중단할 수 있어야 한다', () => {
+  it('leading 옵션이 false인 경우 첫 번째 호출을 무시해야 한다', () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, { leading: false })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(0);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('leading: false 옵션을 사용할 때는 첫 호출이 트리거되지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, { leading: false })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(0);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('trailing: false 옵션을 사용할 때는 마지막 호출이 트리거되지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, { trailing: false })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(1);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(1);
+  });
+
+  it('leading: true, trailing: true 옵션을 사용할 때는 첫 호출과 마지막 호출이 트리거되어야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, {
+        leading: true,
+        trailing: true,
+      })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(1);
+
+    result.current();
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(2);
+  });
+
+  it('leading: false 와 trailing: false 옵션을 사용할 때는 첫 호출과 마지막 호출이 모두 트리거되지 않아야 한다', async () => {
+    const mockFn = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, {
+        leading: false,
+        trailing: false,
+      })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(0);
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(0);
+  });
+
+  it('AbortController을 통해 초기 호출을 중단할 수 있어야 한다', async () => {
     const mockFn = vi.fn();
     const controller = new AbortController();
-
     controller.abort();
 
     const { result } = renderHook(() =>
@@ -124,10 +179,28 @@ describe('useThrottle', () => {
     );
 
     result.current();
-
     expect(mockFn).toBeCalledTimes(0);
 
     vi.advanceTimersByTime(DELAY_TIME);
     expect(mockFn).toBeCalledTimes(0);
+  });
+
+  it('AbortController을 통해 후행 호출을 중단할 수 있어야 한다', async () => {
+    const mockFn = vi.fn();
+    const controller = new AbortController();
+
+    const { result } = renderHook(() =>
+      useThrottle(mockFn, DELAY_TIME, { signal: controller.signal })
+    );
+
+    result.current();
+    expect(mockFn).toBeCalledTimes(1);
+
+    result.current();
+
+    controller.abort();
+
+    vi.advanceTimersByTime(DELAY_TIME);
+    expect(mockFn).toBeCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Overview

chore: modern-kit/react 내에 lodash 함수들 modern-kit/utils 함수로 대체 및 테스트 코드 개선

## PR Checklist
- [x] All tests pass.
- [x] All type checks pass.
- [x] I have read the Contributing Guide document.
    [Contributing Guide](https://github.com/modern-agile-team/modern-kit/blob/main/.github/CONTRIBUTING.md)